### PR TITLE
fix: Update GitHub links to point to correct repository

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -8,8 +8,8 @@ Thank you for your interest in contributing to **FAIR²**—a community-driven s
 
 We welcome contributors from diverse backgrounds and expertise. To stay informed and connected:
 
-- Follow [FAIR² on GitHub](https://github.com/fair2-spec) for repositories and updates.
-- Track development via [issues](https://github.com/fair2-spec/issues) and [pull requests](https://github.com/fair2-spec/pulls).
+- Follow [FAIR² on GitHub](https://github.com/fair-squared/fair2-spec) for repositories and updates.
+- Track development via [issues](https://github.com/fair-squared/fair2-spec/issues) and [pull requests](https://github.com/fair-squared/fair2-spec/pulls).
 - Join the mailing list (coming soon) for community discussions.
 - For general inquiries, contact [info@fair2.ai](mailto:info@fair2.ai).
 
@@ -33,13 +33,13 @@ If you have suggestions or proposals, please reach out to [feedback@fair2.ai](ma
 
 To propose changes to the specification, schema, or documentation:
 
-1. **Fork the repository** at [github.com/fair2-spec](https://github.com/fair2-spec).
+1. **Fork the repository** at [github.com/fair-squared/fair2-spec](https://github.com/fair-squared/fair2-spec).
 2. **Create a feature branch** for your proposed changes.
 3. **Write clear and descriptive commit messages**.
 4. **Submit a pull request (PR)** with a concise summary of the changes.
 5. **Engage with reviewers** to refine and finalize the submission.
 
-Please review the [Contributor Guidelines](https://github.com/fair2-spec/CONTRIBUTING.md) before submitting a pull request.
+Please review the [Contributor Guidelines](https://github.com/fair-squared/fair2-spec/CONTRIBUTING.md) before submitting a pull request.
 
 ---
 
@@ -76,8 +76,8 @@ All contributors and participants are expected to adhere to the [FAIR² Code of 
 
 To begin contributing:
 
-- Browse and comment on open [GitHub issues](https://github.com/fair2-spec/issues).
-- Share feedback via [feedback@fair2.ai](mailto:feedback@fair2.ai).
+- Browse and comment on open [GitHub issues](https://github.com/fair-squared/fair2-spec/issues).
+- Share feedback via [feedback@fair-squared/fair2.ai](mailto:feedback@fair2.ai).
 - Join our upcoming community discussions and working groups (details coming soon).
 
 We are grateful for your support in building FAIR² into a trusted standard for machine-actionable, AI-ready FAIR data.

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -77,7 +77,7 @@ All contributors and participants are expected to adhere to the [FAIR² Code of 
 To begin contributing:
 
 - Browse and comment on open [GitHub issues](https://github.com/fair-squared/fair2-spec/issues).
-- Share feedback via [feedback@fair-squared/fair2.ai](mailto:feedback@fair2.ai).
+- Share feedback via [feedback@fair2.ai](mailto:feedback@fair2.ai).
 - Join our upcoming community discussions and working groups (details coming soon).
 
 We are grateful for your support in building FAIR² into a trusted standard for machine-actionable, AI-ready FAIR data.

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -16,7 +16,7 @@ All participants are expected to adhere to the [FAIR² Code of Conduct](code-of-
 
 There are multiple ways to participate in the FAIR² governance process:
 
-1. **Propose improvements** via [GitHub Issues](https://github.com/fair2-spec) or pull requests
+1. **Propose improvements** via [GitHub Issues](https://github.com/fair-squared/fair2-spec) or pull requests
 2. **Join discussions** in community meetings and working groups
 3. **Adopt FAIR²** in your datasets, platforms, or tools
 4. **Contribute to outreach** through workshops, writing, or speaking engagements

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -52,7 +52,7 @@ This phase invites the broader community to test, implement, and critique the FA
 - 🔜 Iterative updates to ontology, validation rules, and documentation based on feedback  
 
 **Join the feedback process:**  
-[github.com/fair2-spec](https://github.com/fair2-spec)  
+[github.com/fair-squared/fair2-spec](https://github.com/fair-squared/fair2-spec)  
 [community@fair2.ai](mailto:community@fair2.ai)
 
 ---
@@ -80,7 +80,7 @@ This phase focuses on formalizing adoption pathways and compliance verification 
 
 FAIR² is a collaborative project, and community input is essential to its evolution. You can contribute by:
 
-- Submitting feature proposals or revisions via [GitHub Issues](https://github.com/fair2-spec/issues)  
+- Submitting feature proposals or revisions via [GitHub Issues](https://github.com/fair-squared/fair2-spec/issues)  
 - Assisting with SHACL rule testing and FAIR² Validator feedback  
 - Promoting adoption within academic, clinical, or industrial settings  
 
@@ -93,7 +93,7 @@ FAIR² is a collaborative project, and community input is essential to its evolu
 
 - [Explore the FAIR² Specification](../specification/overview.md)  
 - [Contribute to FAIR²](contributing.md)  
-- [Engage in ongoing discussions](https://github.com/fair2-spec/issues)
+- [Engage in ongoing discussions](https://github.com/fair-squared/fair2-spec/issues)
 
 ---
 

--- a/docs/integration/contributor-roles.md
+++ b/docs/integration/contributor-roles.md
@@ -147,7 +147,7 @@ To begin using contributor roles in FAIR²:
 1. Review the [Getting Started Guide](../getting-started.md)
 2. Examine the [FAIR² Schema](../specification/schema.md) for contribution properties
 3. Validate contributor metadata using [SHACL rules](../specification/shacl-validation.md)
-4. Join ongoing discussions on extending role support via [GitHub Issues](https://github.com/fair2-spec/issues)
+4. Join ongoing discussions on extending role support via [GitHub Issues](https://github.com/fair-squared/fair2-spec/issues)
 
 For contribution-related inquiries or suggestions, please contact:  
 📩 [feedback@fair2.ai](mailto:feedback@fair2.ai)

--- a/docs/integration/google-rich-search.md
+++ b/docs/integration/google-rich-search.md
@@ -89,4 +89,4 @@ To ensure compatibility with search engines and FAIR² validation:
 
 - Refer to the [FAIR² Schema](../specification/schema.md) for additional properties
 - Test rich result compatibility using [Google’s Rich Results Test](https://search.google.com/test/rich-results)
-- Contribute improvements or extensions via [GitHub](https://github.com/fair2-spec/issues)
+- Contribute improvements or extensions via [GitHub](https://github.com/fair-squared/fair2-spec/issues)

--- a/docs/integration/odps.md
+++ b/docs/integration/odps.md
@@ -95,4 +95,4 @@ Including ODPS metadata within FAIR² enables:
 
 - Refer to the [FAIR² Schema](../specification/schema.md) for usage examples
 - Review the [ODPS documentation](https://opendataproducts.org/specification/)
-- Submit extensions or validation rules via [GitHub](https://github.com/fair2-spec/issues)
+- Submit extensions or validation rules via [GitHub](https://github.com/fair-squared/fair2-spec/issues)

--- a/docs/integration/prov-o.md
+++ b/docs/integration/prov-o.md
@@ -82,4 +82,4 @@ To include provenance metadata using PROV-O in FAIR²:
 1. Refer to the [FAIR² Schema](../specification/schema.md) for relevant properties.
 2. Incorporate PROV-O terms into your dataset JSON-LD metadata.
 3. Validate using [SHACL rules](../specification/shacl-validation.md).
-4. Contribute examples or feedback via [GitHub Issues](https://github.com/fair2-spec/issues) or [feedback@fair2.ai](mailto:feedback@fair2.ai).
+4. Contribute examples or feedback via [GitHub Issues](https://github.com/fair-squared/fair2-spec/issues) or [feedback@fair2.ai](mailto:feedback@fair2.ai).


### PR DESCRIPTION
When reading the docs on https://fair-squared.github.io/fair2-spec/specification/overview/ I noticed that several of the links to view the repository or file issues were broken.

This PR updates those broken GitHub links to point to the correct repo.