### PR TITLE
Enrich example-1, standardize context, complete shapes & docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/croissant-compatibility.md
+++ b/.github/ISSUE_TEMPLATE/croissant-compatibility.md
@@ -1,0 +1,69 @@
+---
+name: Croissant / mlcroissant compatibility
+about: Report a FAIR²-to-Croissant (mlcroissant) loading or validation incompatibility
+title: "[croissant] "
+labels: ["bug", "integration:croissant"]
+assignees: []
+---
+
+## Summary
+
+<!-- One or two sentences: which file, and what fails. -->
+
+- Affected file(s):
+- `mlcroissant` version:
+- SHACL validation status (passes? `pyshacl -s <shapes> -d <file>`):
+
+## Reproduction
+
+```python
+import mlcroissant as mlc
+mlc.Dataset(jsonld="examples/.../<file>.json")
+```
+
+Error / traceback:
+
+```
+<paste the exception here>
+```
+
+## Background — known limitation
+
+`mlcroissant`'s JSON-LD loader (`recursively_populate_jsonld`) flattens the graph
+with `rdflib`, then re-nests it by **inlining every `{"@id": "X"}` reference and
+mutating the target node in place**. As a result it raises a `KeyError` whenever a
+node is reached more than once from the entry `Dataset` — i.e. when a node is:
+
+1. part of a reference **cycle** (e.g. `Dataset.url` equal to the dataset's own
+   `@id`; a `geoWithin` back-link that mirrors a `containsPlace`; a
+   `DataArticle.wasDerivedFrom` / `DataPortal.dataset` / `DataArchive.dataset`
+   pointing back at the `Dataset`); or
+2. referenced via **two different paths** (a shared `@graph` node referenced from
+   more than one place).
+
+These are the failure modes documented in
+[`docs/integration/ml-croissant.md`](../../docs/integration/ml-croissant.md)
+(Compatibility Rules 1–6). The FAIR² normalized `@graph` serialization can hit
+them because it cross-links extension entities (`DataPortal`, `DataArchive`,
+`DataArticle`, `Activity`, `SoftwareAgent`, method `source/*`).
+
+## Checklist before filing
+
+- [ ] No node forms a reference cycle (no self-referential `url`, no
+      `geoWithin`⇄`containsPlace`, no back-links to the `Dataset` `@id`).
+- [ ] Cross-graph reference properties do **not** use `"@type": "@id"` in the
+      `@context` (Rule 2).
+- [ ] Repeated entities are emitted as fresh blank nodes, or referenced exactly
+      once (Rules 1 & 4).
+- [ ] `@context` includes `@language` (mlcroissant requires it).
+- [ ] FileObject checksums use `schema:sha256` (or `md5`), and `@type` is
+      `cr:FileObject` (Rules 5 & 6).
+- [ ] SHACL validation (`pyshacl`) still reports `Conforms: True`.
+
+## Proposed fix / acceptance criteria
+
+- [ ] `mlcroissant.Dataset(jsonld=...)` loads with no exception and exposes
+      `metadata.name`, `record_sets`, and `distribution`.
+- [ ] SHACL validation continues to pass.
+- [ ] (If applicable) a regression test loads every `examples/**` file through
+      `mlcroissant`.

--- a/context/metadata/fair2_context.json
+++ b/context/metadata/fair2_context.json
@@ -1,370 +1,625 @@
 {
-    "@id": "https://fair2.ai/spec/fair2_context",
-    "@context": [
-        "https://schema.org/",
-        "https://w3id.org/croissant/v1.0.0",
-        {
-            "@vocab": "https://schema.org/",
-            "Article": {
-            "@id": "schema:Article"
-            },
-            "Audience": {
-            "@id": "fair2:Audience"
-            },
-            "CreativeWork": {
-            "@id": "schema:CreativeWork"
-            },
-            "Dataset": {
-            "@id": "schema:Dataset"
-            },
-            "DefinedTermSet": {
-            "@id": "schema:DefinedTermSet"
-            },
-            "DescriptiveStatistics": {
-            "@id": "fair2:DescriptiveStatistics"
-            },
-            "Event": {
-            "@id": "schema:Event"
-            },
-            "ExperimentDataset": {
-            "@id": "fair2:ExperimentDataset",
-            "@type": "schema:Dataset"
-            },
-            "Field": {
-            "@id": "cr:Field"
-            },
-            "FileObject": {
-            "@id": "cr:FileObject"
-            },
-            "HowToStep": {
-            "@id": "schema:HowToStep"
-            },
-            "Offer": {
-            "@id": "schema:Offer"
-            },
-            "OpenDataArticleSection": {
-            "@id": "fair2:OpenDataArticleSection",
-            "@type": "schema:Text"
-            },
-            "Organization": {
-            "@id": "schema:Organization"
-            },
-            "Person": {
-            "@id": "schema:Person"
-            },
-            "Place": {
-            "@id": "schema:Place"
-            },
-            "Product": {
-            "@id": "schema:Product"
-            },
-            "RecordSet": {
-            "@id": "cr:RecordSet"
-            },
-            "Role": {
-            "@id": "fair2:Role"
-            },
-            "Section": {
-            "@id": "fair2:Section"
-            },
-            "Step": {
-            "@id": "fair2:Step",
-            "@type": "schema:HowToStep"
-            },
-            "Submission": {
-            "@id": "fair2:Submission"
-            },
-            "DataPortal": {
-            "@id": "fair2:DataPortal"
-            },
-            "DataArchive": {
-            "@id": "fair2:DataArchive"
-            },
-            "DigitalDocument": {
-            "@id": "schema:DigitalDocument"
-            },
-            "SoftwareSourceCode": {
-            "@id": "schema:SoftwareSourceCode"
-            },
-            "Activity": {
-            "@id": "prov:Activity"
-            },
-            "SoftwareAgent": {
-            "@id": "prov:SoftwareAgent"
-            },
-            "Substep": {
-            "@id": "fair2:Substep"
-            },
-            "Text": {
-            "@id": "schema:Text"
-            },
-            "Visualization": {
-            "@id": "fair2:Visualization"
-            },
-            "activities": {
-            "@id": "fair2:activities"
-            },
-            "address": {
-            "@id": "schema:address"
-            },
-            "affiliation": {
-            "@id": "schema:affiliation"
-            },
-            "annotatorDemographics": {
-            "@id": "rai:annotatorDemographics"
-            },
-            "annotationsPerItem": {
-            "@id": "rai:annotationsPerItem"
-            },
-            "articleBody": {
-            "@id": "schema:articleBody"
-            },
-            "attachment": {
-            "@id": "fair2:attachment"
-            },
-            "author": {
-            "@id": "schema:author"
-            },
-            "Certification": {
-            "@id": "fair2:Certification"
-            },
-            "certificationDocument": {
-            "@id": "fair2:certificationDocument"
-            },
-            "certificationScope": {
-            "@id": "fair2:certificationScope"
-            },
-            "certifiedBy": {
-            "@id": "fair2:certifiedBy"
-            },
-            "creator": {
-            "@id": "schema:creator"
-            },
-            "brand": {
-            "@id": "schema:brand"
-            },
-            "builds": {
-            "@id": "fair2:builds"
-            },
-            "citeAs": {
-            "@id": "cr:citeAs"
-            },
-            "changeLog": {
-            "@id": "fair2:changeLog"
-            },
-            "column": {
-            "@id": "cr:column"
-            },
-            "conformsTo": {
-            "@id": "dct:conformsTo"
-            },
-            "contributorRole": {
-            "@id": "fair2:contributorRole"
-            },
-            "cr": "http://mlcommons.org/croissant/",
-            "cro": "http://purl.obolibrary.org/obo/CRO_",
-            "credit": "http://purl.org/credit/ontology#CREDIT_",
-            "dataAnnotationAnalysis": {
-            "@id": "rai:dataAnnotationAnalysis"
-            },
-            "dataAnnotationPlatform": {
-            "@id": "rai:dataAnnotationPlatform"
-            },
-            "dataAnnotationProtocol": {
-            "@id": "rai:dataAnnotationProtocol"
-            },
-            "dataBiases": {
-            "@id": "rai:dataBiases"
-            },
-            "dataCollection": {
-            "@id": "rai:dataCollection"
-            },
-            "dataCollectionMissingData": {
-            "@id": "rai:dataCollectionMissingData"
-            },
-            "dataCollectionRawData": {
-            "@id": "rai:dataCollectionRawData"
-            },
-            "dataCollectionTimeframe": {
-            "@id": "rai:dataCollectionTimeframe"
-            },
-            "dataCollectionType": {
-            "@id": "rai:dataCollectionType"
-            },
-            "dataImputationProtocol": {
-            "@id": "rai:dataImputationProtocol"
-            },
-            "dataLimitations": {
-            "@id": "rai:dataLimitations"
-            },
-            "dataManipulationProtocol": {
-            "@id": "rai:dataManipulationProtocol"
-            },
-            "dataPreprocessingProtocol": {
-            "@id": "rai:dataPreprocessingProtocol"
-            },
-            "dataReleaseMaintenancePlan": {
-            "@id": "rai:dataReleaseMaintenancePlan"
-            },
-            "dataSocialImpact": {
-            "@id": "rai:dataSocialImpact"
-            },
-            "dataType": {
-            "@id": "cr:dataType",
-            "@type": "@vocab"
-            },
-            "dataUseCases": {
-            "@id": "rai:dataUseCases"
-            },
-            "dataset": {
-            "@id": "fair2:dataset"
-            },
-            "dataPortal": {
-            "@id": "fair2:dataPortal"
-            },
-            "dataArchive": {
-            "@id": "fair2:dataArchive"
-            },
-            "used": {
-            "@id": "prov:used",
-            "@type": "@id"
-            },
-            "wasAssociatedWith": {
-            "@id": "prov:wasAssociatedWith"
-            },
-            "wasGeneratedBy": {
-            "@id": "prov:wasGeneratedBy"
-            },
-            "softwareVersion": {
-            "@id": "schema:softwareVersion"
-            },
-            "programmingLanguage": {
-            "@id": "schema:programmingLanguage"
-            },
-            "runtimePlatform": {
-            "@id": "schema:runtimePlatform"
-            },
-            "pagination": {
-            "@id": "schema:pagination"
-            },
-            "dateIssued": {
-            "@id": "fair2:dateIssued"
-            },
-            "datePublished": {
-            "@id": "schema:datePublished"
-            },
-            "fair2ComplianceLevel": {
-            "@id": "fair2:fair2ComplianceLevel"
-            },
-            "verificationEndpoint": {
-            "@id": "fair2:verificationEndpoint"
-            },
-            "dct": "http://purl.org/dc/terms/",
-            "description": {
-            "@id": "schema:description"
-            },
-            "digest": {
-            "@id": "fair2:digest"
-            },
-            "email": {
-            "@id": "schema:email"
-            },
-            "extract": {
-            "@id": "cr:extract"
-            },
-            "familyName": {
-            "@id": "schema:familyName"
-            },
-            "fair2": "https://fair2.ai/ns/",
-            "fair2s": "https://fair2.ai/shapes/",
-            "field": {
-            "@id": "cr:field"
-            },
-            "fileObject": {
-            "@id": "cr:fileObject"
-            },
-            "geo": {
-            "@id": "schema:geo"
-            },
-            "givenName": {
-            "@id": "schema:givenName"
-            },
-            "hadRole": {
-            "@id": "prov:hadRole"
-            },
-            "headline": {
-            "@id": "schema:headline"
-            },
-            "image": {
-            "@id": "schema:image"
-            },
-            "location": {
-            "@id": "schema:location"
-            },
-            "logo": {
-            "@id": "schema:logo"
-            },
-            "machineAnnotationTools": {
-            "@id": "rai:machineAnnotationTools"
-            },
-            "manuscript": {
-            "@id": "fair2:manuscript"
-            },
-            "methodSection": {
-            "@id": "fair2:methodSection"
-            },
-            "name": {
-            "@id": "schema:name"
-            },
-            "offers": {
-            "@id": "schema:offers"
-            },
-            "organizer": {
-            "@id": "schema:organizer"
-            },
-            "personalSensitiveInformation": {
-            "@id": "rai:personalSensitiveInformation"
-            },
-            "price": {
-            "@id": "schema:price"
-            },
-            "priceCurrency": {
-            "@id": "schema:priceCurrency"
-            },
-            "prov": "http://www.w3.org/ns/prov#",
-            "publisher": {
-            "@id": "schema:publisher"
-            },
-            "rai": "http://mlcommons.org/croissant/RAI/",
-            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-            "recordSet": {
-            "@id": "cr:recordSet"
-            },
-            "roleName": {
-            "@id": "fair2:roleName"
-            },
-            "source": {
-            "@id": "cr:source"
-            },
-            "startDate": {
-            "@id": "schema:startDate"
-            },
-            "statistics": {
-            "@id": "fair2:statistics"
-            },
-            "step": {
-            "@id": "fair2:step"
-            },
-            "store": {
-            "@id": "fair2:store"
-            },
-            "url": {
-            "@id": "schema:url"
-            },
-            "variable": {
-            "@id": "fair2:variable",
-            "@type": "schema:DefinedTermSet"
-            }
-        }
-    ]
+  "@id": "https://fair2.ai/spec/fair2_context",
+  "@context": [
+    "https://schema.org/",
+    "https://w3id.org/croissant/v1.0.0",
+    {
+      "@vocab": "https://schema.org/",
+      "cr": "http://mlcommons.org/croissant/",
+      "credit": "http://purl.org/credit/ontology#CREDIT_",
+      "cro": "http://purl.obolibrary.org/obo/CRO_",
+      "dct": "http://purl.org/dc/terms/",
+      "fair2": "https://fair2.ai/ns/",
+      "fair2s": "https://fair2.ai/shapes/",
+      "prov": "http://www.w3.org/ns/prov#",
+      "rai": "http://mlcommons.org/croissant/RAI/",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/",
+      "sh": "http://www.w3.org/ns/shacl#",
+      "skos": "http://www.w3.org/2004/02/skos/core#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "Activity": {
+        "@id": "prov:Activity"
+      },
+      "Article": {
+        "@id": "schema:Article"
+      },
+      "Audience": {
+        "@id": "fair2:Audience"
+      },
+      "AuthorRole": {
+        "@id": "fair2:AuthorRole"
+      },
+      "Boolean": {
+        "@id": "schema:Boolean"
+      },
+      "Certification": {
+        "@id": "fair2:Certification"
+      },
+      "ContributorRole": {
+        "@id": "fair2:ContributorRole"
+      },
+      "CreativeWork": {
+        "@id": "schema:CreativeWork"
+      },
+      "DataArchive": {
+        "@id": "fair2:DataArchive"
+      },
+      "DataArticle": {
+        "@id": "fair2:DataArticle",
+        "@type": "schema:ScholarlyArticle"
+      },
+      "DataDownload": {
+        "@id": "schema:DataDownload"
+      },
+      "DataPortal": {
+        "@id": "fair2:DataPortal"
+      },
+      "Dataset": {
+        "@id": "schema:Dataset"
+      },
+      "Date": {
+        "@id": "schema:Date"
+      },
+      "DateTime": {
+        "@id": "schema:DateTime"
+      },
+      "DefinedTerm": {
+        "@id": "schema:DefinedTerm"
+      },
+      "DefinedTermSet": {
+        "@id": "schema:DefinedTermSet"
+      },
+      "DescriptiveStatistics": {
+        "@id": "fair2:DescriptiveStatistics"
+      },
+      "DigitalDocument": {
+        "@id": "schema:DigitalDocument"
+      },
+      "Duration": {
+        "@id": "schema:Duration"
+      },
+      "Event": {
+        "@id": "schema:Event"
+      },
+      "ExperimentDataset": {
+        "@id": "fair2:ExperimentDataset",
+        "@type": "schema:Dataset"
+      },
+      "Field": {
+        "@id": "cr:Field"
+      },
+      "FileObject": {
+        "@id": "cr:FileObject"
+      },
+      "Float": {
+        "@id": "schema:Float"
+      },
+      "GeoShape": {
+        "@id": "schema:GeoShape"
+      },
+      "HowTo": {
+        "@id": "schema:HowTo"
+      },
+      "HowToSection": {
+        "@id": "schema:HowToSection"
+      },
+      "HowToStep": {
+        "@id": "schema:HowToStep"
+      },
+      "Integer": {
+        "@id": "schema:Integer"
+      },
+      "Location": {
+        "@id": "schema:Location"
+      },
+      "Number": {
+        "@id": "schema:Number"
+      },
+      "Offer": {
+        "@id": "schema:Offer"
+      },
+      "OpenDataArticleSection": {
+        "@id": "fair2:OpenDataArticleSection",
+        "@type": "schema:Text"
+      },
+      "Organization": {
+        "@id": "schema:Organization"
+      },
+      "Periodical": {
+        "@id": "schema:Periodical"
+      },
+      "Person": {
+        "@id": "schema:Person"
+      },
+      "Place": {
+        "@id": "schema:Place"
+      },
+      "Product": {
+        "@id": "schema:Product"
+      },
+      "PropertyValue": {
+        "@id": "schema:PropertyValue"
+      },
+      "Rating": {
+        "@id": "schema:Rating"
+      },
+      "RecordSet": {
+        "@id": "cr:RecordSet"
+      },
+      "Role": {
+        "@id": "fair2:Role"
+      },
+      "ScholarlyArticle": {
+        "@id": "schema:ScholarlyArticle"
+      },
+      "Section": {
+        "@id": "fair2:Section",
+        "@type": "schema:HowToSection"
+      },
+      "SoftwareAgent": {
+        "@id": "prov:SoftwareAgent"
+      },
+      "SoftwareSourceCode": {
+        "@id": "schema:SoftwareSourceCode"
+      },
+      "Step": {
+        "@id": "fair2:Step",
+        "@type": "schema:HowToStep"
+      },
+      "Submission": {
+        "@id": "fair2:Submission"
+      },
+      "Substep": {
+        "@id": "fair2:Substep"
+      },
+      "Text": {
+        "@id": "schema:Text"
+      },
+      "Visualization": {
+        "@id": "fair2:Visualization"
+      },
+      "accessRights": {
+        "@id": "dct:accessRights"
+      },
+      "activities": {
+        "@id": "fair2:activities"
+      },
+      "address": {
+        "@id": "schema:address"
+      },
+      "affiliation": {
+        "@id": "schema:affiliation"
+      },
+      "algorithm": {
+        "@id": "schema:algorithm"
+      },
+      "alternateName": {
+        "@id": "schema:alternateName"
+      },
+      "annotationsPerItem": {
+        "@id": "rai:annotationsPerItem"
+      },
+      "annotatorDemographics": {
+        "@id": "rai:annotatorDemographics"
+      },
+      "articleBody": {
+        "@id": "schema:articleBody"
+      },
+      "atLocation": {
+        "@id": "schema:atLocation"
+      },
+      "attachment": {
+        "@id": "fair2:attachment"
+      },
+      "author": {
+        "@id": "schema:author"
+      },
+      "box": {
+        "@id": "schema:box"
+      },
+      "brand": {
+        "@id": "schema:brand"
+      },
+      "bugFixes": {
+        "@id": "fair2:bugFixes"
+      },
+      "builds": {
+        "@id": "fair2:builds"
+      },
+      "certificationDocument": {
+        "@id": "fair2:certificationDocument"
+      },
+      "certificationScope": {
+        "@id": "fair2:certificationScope"
+      },
+      "certifiedBy": {
+        "@id": "fair2:certifiedBy"
+      },
+      "changeLog": {
+        "@id": "fair2:changeLog"
+      },
+      "citation": {
+        "@id": "schema:citation"
+      },
+      "citationKey": {
+        "@id": "fair2:citationKey"
+      },
+      "citeAs": {
+        "@id": "cr:citeAs"
+      },
+      "column": {
+        "@id": "cr:column"
+      },
+      "conformsTo": {
+        "@id": "dct:conformsTo"
+      },
+      "containsPlace": {
+        "@id": "schema:containsPlace"
+      },
+      "contentSize": {
+        "@id": "schema:contentSize"
+      },
+      "contentUrl": {
+        "@id": "schema:contentUrl"
+      },
+      "contributor": {
+        "@id": "schema:contributor"
+      },
+      "contributorRole": {
+        "@id": "fair2:contributorRole"
+      },
+      "creator": {
+        "@id": "schema:creator"
+      },
+      "dataAnnotationAnalysis": {
+        "@id": "rai:dataAnnotationAnalysis"
+      },
+      "dataAnnotationPlatform": {
+        "@id": "rai:dataAnnotationPlatform"
+      },
+      "dataAnnotationProtocol": {
+        "@id": "rai:dataAnnotationProtocol"
+      },
+      "dataArchive": {
+        "@id": "fair2:dataArchive"
+      },
+      "dataArticle": {
+        "@id": "fair2:dataArticle"
+      },
+      "dataBiases": {
+        "@id": "rai:dataBiases"
+      },
+      "dataCollection": {
+        "@id": "rai:dataCollection"
+      },
+      "dataCollectionMissingData": {
+        "@id": "rai:dataCollectionMissingData"
+      },
+      "dataCollectionRawData": {
+        "@id": "rai:dataCollectionRawData"
+      },
+      "dataCollectionTimeframe": {
+        "@id": "rai:dataCollectionTimeframe"
+      },
+      "dataCollectionType": {
+        "@id": "rai:dataCollectionType"
+      },
+      "dataImputationProtocol": {
+        "@id": "rai:dataImputationProtocol"
+      },
+      "dataLimitations": {
+        "@id": "rai:dataLimitations"
+      },
+      "dataManipulationProtocol": {
+        "@id": "rai:dataManipulationProtocol"
+      },
+      "dataPortal": {
+        "@id": "fair2:dataPortal"
+      },
+      "dataPreprocessingProtocol": {
+        "@id": "rai:dataPreprocessingProtocol"
+      },
+      "dataReleaseMaintenancePlan": {
+        "@id": "rai:dataReleaseMaintenancePlan"
+      },
+      "dataSocialImpact": {
+        "@id": "rai:dataSocialImpact"
+      },
+      "dataType": {
+        "@id": "cr:dataType",
+        "@type": "@vocab"
+      },
+      "dataUseCases": {
+        "@id": "rai:dataUseCases"
+      },
+      "dataset": {
+        "@id": "fair2:dataset"
+      },
+      "dateCreated": {
+        "@id": "schema:dateCreated",
+        "@type": "xsd:date"
+      },
+      "dateIssued": {
+        "@id": "fair2:dateIssued",
+        "@type": "xsd:date"
+      },
+      "dateModified": {
+        "@id": "schema:dateModified",
+        "@type": "xsd:date"
+      },
+      "datePublished": {
+        "@id": "schema:datePublished",
+        "@type": "xsd:date"
+      },
+      "dateUpdated": {
+        "@id": "schema:dateUpdated",
+        "@type": "xsd:date"
+      },
+      "definition": {
+        "@id": "skos:definition"
+      },
+      "description": {
+        "@id": "schema:description"
+      },
+      "digest": {
+        "@id": "fair2:digest"
+      },
+      "distribution": {
+        "@id": "schema:distribution"
+      },
+      "domain": {
+        "@id": "fair2:domain"
+      },
+      "email": {
+        "@id": "schema:email"
+      },
+      "encoding": {
+        "@id": "schema:encoding"
+      },
+      "encodingFormat": {
+        "@id": "schema:encodingFormat"
+      },
+      "extract": {
+        "@id": "cr:extract"
+      },
+      "fair2ComplianceLevel": {
+        "@id": "fair2:fair2ComplianceLevel"
+      },
+      "familyName": {
+        "@id": "schema:familyName"
+      },
+      "field": {
+        "@id": "cr:field"
+      },
+      "fileObject": {
+        "@id": "cr:fileObject"
+      },
+      "funder": {
+        "@id": "schema:funder"
+      },
+      "funding": {
+        "@id": "schema:funding"
+      },
+      "fundingScheme": {
+        "@id": "schema:fundingScheme"
+      },
+      "generated": {
+        "@id": "fair2:generated"
+      },
+      "geo": {
+        "@id": "schema:geo"
+      },
+      "geoWithin": {
+        "@id": "schema:geoWithin"
+      },
+      "givenName": {
+        "@id": "schema:givenName"
+      },
+      "hadRole": {
+        "@id": "prov:hadRole"
+      },
+      "hasPart": {
+        "@id": "schema:hasPart"
+      },
+      "headline": {
+        "@id": "schema:headline"
+      },
+      "holdingArchive": {
+        "@id": "schema:holdingArchive"
+      },
+      "image": {
+        "@id": "schema:image"
+      },
+      "improvements": {
+        "@id": "fair2:improvements"
+      },
+      "isBasedOn": {
+        "@id": "schema:isBasedOn"
+      },
+      "isExperimentRelated": {
+        "@id": "fair2:isExperimentRelated"
+      },
+      "keywords": {
+        "@id": "schema:keywords"
+      },
+      "label": {
+        "@id": "rdfs:label"
+      },
+      "latitude": {
+        "@id": "schema:latitude"
+      },
+      "license": {
+        "@id": "schema:license"
+      },
+      "location": {
+        "@id": "schema:location"
+      },
+      "logo": {
+        "@id": "schema:logo"
+      },
+      "longitude": {
+        "@id": "schema:longitude"
+      },
+      "machineAnnotationTools": {
+        "@id": "rai:machineAnnotationTools"
+      },
+      "manuscript": {
+        "@id": "fair2:manuscript"
+      },
+      "methodSection": {
+        "@id": "fair2:methodSection"
+      },
+      "name": {
+        "@id": "schema:name"
+      },
+      "newFeatures": {
+        "@id": "fair2:newFeatures"
+      },
+      "next": {
+        "@id": "fair2:next"
+      },
+      "nextTrue": {
+        "@id": "fair2:nextTrue"
+      },
+      "note": {
+        "@id": "skos:note"
+      },
+      "offers": {
+        "@id": "schema:offers"
+      },
+      "organizer": {
+        "@id": "schema:organizer"
+      },
+      "otherInformation": {
+        "@id": "fair2:otherInformation"
+      },
+      "pagination": {
+        "@id": "schema:pagination"
+      },
+      "personalSensitiveInformation": {
+        "@id": "rai:personalSensitiveInformation"
+      },
+      "polygon": {
+        "@id": "schema:polygon"
+      },
+      "price": {
+        "@id": "schema:price"
+      },
+      "priceCurrency": {
+        "@id": "schema:priceCurrency"
+      },
+      "programmingLanguage": {
+        "@id": "schema:programmingLanguage"
+      },
+      "propertyID": {
+        "@id": "schema:propertyID"
+      },
+      "publication": {
+        "@id": "schema:publication"
+      },
+      "publisher": {
+        "@id": "schema:publisher"
+      },
+      "qualifiedUsage": {
+        "@id": "fair2:qualifiedUsage"
+      },
+      "recordSet": {
+        "@id": "cr:recordSet"
+      },
+      "roleName": {
+        "@id": "fair2:roleName"
+      },
+      "runtimePlatform": {
+        "@id": "schema:runtimePlatform"
+      },
+      "sha256": {
+        "@id": "schema:sha256"
+      },
+      "softwareVersion": {
+        "@id": "schema:softwareVersion"
+      },
+      "source": {
+        "@id": "cr:source"
+      },
+      "spatialCoverage": {
+        "@id": "schema:spatialCoverage"
+      },
+      "startDate": {
+        "@id": "schema:startDate"
+      },
+      "statistics": {
+        "@id": "fair2:statistics"
+      },
+      "step": {
+        "@id": "fair2:step"
+      },
+      "store": {
+        "@id": "fair2:store"
+      },
+      "subjectOf": {
+        "@id": "schema:subjectOf"
+      },
+      "substep": {
+        "@id": "fair2:substep"
+      },
+      "symbol": {
+        "@id": "schema:symbol"
+      },
+      "temporalCoverage": {
+        "@id": "schema:temporalCoverage"
+      },
+      "unit": {
+        "@id": "fair2:unit"
+      },
+      "unitCode": {
+        "@id": "schema:unitCode"
+      },
+      "url": {
+        "@id": "schema:url"
+      },
+      "used": {
+        "@id": "prov:used",
+        "@type": "@id"
+      },
+      "value": {
+        "@id": "schema:value"
+      },
+      "variable": {
+        "@id": "fair2:variable",
+        "@type": "schema:DefinedTermSet"
+      },
+      "variableMeasured": {
+        "@id": "schema:variableMeasured"
+      },
+      "variables": {
+        "@id": "fair2:variables",
+        "@type": "schema:DefinedTermSet"
+      },
+      "verificationEndpoint": {
+        "@id": "fair2:verificationEndpoint"
+      },
+      "version": {
+        "@id": "schema:version"
+      },
+      "visualization": {
+        "@id": "fair2:visualization"
+      },
+      "wasAssociatedWith": {
+        "@id": "prov:wasAssociatedWith"
+      },
+      "wasAttributedTo": {
+        "@id": "prov:wasAttributedTo"
+      },
+      "wasDerivedFrom": {
+        "@id": "prov:wasDerivedFrom"
+      },
+      "wasGeneratedBy": {
+        "@id": "prov:wasGeneratedBy"
+      },
+      "wasRevisionOf": {
+        "@id": "prov:wasRevisionOf"
+      }
+    }
+  ]
 }

--- a/docs/specification/fair2-ontology.md
+++ b/docs/specification/fair2-ontology.md
@@ -29,10 +29,16 @@ The following classes define the core conceptual entities in FAIR². Each class 
 
 | `@id` | `rdfs:label` | `rdfs:comment` | `rdfs:subClassOf` |
 |:------|:--------------|:----------------|:------------------|
-| `fair2:OpenDataArticle` | OpenDataArticle | Scholarly work describing and linking an open dataset with methods and reuse guidance. | `schema:ScholarlyArticle` |
-| `fair2:MethodSection` | MethodSection | Structured section grouping procedural steps for a method. | `schema:HowToSection` |
+| `fair2:DataArticle` | DataArticle | Scholarly article describing and linking an open dataset with methods and reuse guidance. | `schema:ScholarlyArticle` |
+| `fair2:OpenDataArticle` | OpenDataArticle | Legacy alias for `fair2:DataArticle`; retained for backward compatibility. | `schema:ScholarlyArticle` |
+| `fair2:DataPortal` | DataPortal | An online portal or platform that hosts and serves the dataset. | `schema:CreativeWork` |
+| `fair2:DataArchive` | DataArchive | A long-term archive or repository that preserves the dataset. | `schema:CreativeWork` |
+| `fair2:Section` | Section | Structured methodology section grouping procedural steps. | `schema:HowToSection` |
+| `fair2:MethodSection` | MethodSection | Legacy alias for `fair2:Section`; retained for backward compatibility. | `schema:HowToSection` |
 | `fair2:Step` | Step | Atomic procedural instruction within a method. | `schema:HowToStep` |
 | `fair2:Substep` | Substep | Subordinate procedural instruction nested under a Step. | `schema:HowToStep` |
+| `fair2:AuthorRole` | AuthorRole | Role played by an author in producing the dataset (e.g. Corresponding Author). | `schema:Role` |
+| `fair2:ContributorRole` | ContributorRole | Contributor role drawn from CRediT/CRO vocabularies. | `schema:Role` |
 | `fair2:RecordSet` | RecordSet | A coherent subset of a dataset used for analysis or curation. | `schema:Dataset` |
 | `fair2:Visualization` | Visualization | A visual artifact (plot, figure, dashboard) derived from the dataset. | `schema:CreativeWork` |
 | `fair2:DescriptiveStatistics` | DescriptiveStatistics | Summary statistics computed over a RecordSet or Dataset. | `schema:Dataset` |
@@ -49,15 +55,31 @@ The FAIR² properties define relationships between datasets, methods, contributo
 | `fair2:activities` | activities | Groups workflow or provenance activities related to an entity. |
 | `fair2:attachment` | attachment | Points to a supporting file or supplemental material. |
 | `fair2:builds` | builds | Indicates that one artifact is built from or extends another artifact. |
+| `fair2:bugFixes` | bugFixes | Bug-fix entries within a changelog update description. |
+| `fair2:citationKey` | citationKey | Short citation key identifying the dataset. |
 | `fair2:contributorRole` | contributorRole | Links a contribution to a contributor role term. |
+| `fair2:dataArchive` | dataArchive | Links a dataset to the archive that preserves it. |
 | `fair2:dataArticle` | dataArticle | Links a dataset or submission to its associated scholarly data article. |
+| `fair2:dataPortal` | dataPortal | Links a dataset to the portal that hosts and serves it. |
 | `fair2:dataset` | dataset | References the dataset resource associated with the entity. |
 | `fair2:digest` | digest | Provides a short textual or hash-based digest for quick identification. |
+| `fair2:domain` | domain | Subject-domain classification of the dataset (e.g. a Wikidata concept). |
+| `fair2:generated` | generated | Links a method step to the RecordSet fields or artifacts it produced (lineage). |
+| `fair2:improvements` | improvements | Improvement entries within a changelog update description. |
+| `fair2:isExperimentRelated` | isExperimentRelated | Flags whether a field relates to experimental data. |
 | `fair2:manuscript` | manuscript | References a manuscript file associated with the submission. |
+| `fair2:methodSection` | methodSection | Links a dataset to its methodology section(s). |
+| `fair2:newFeatures` | newFeatures | New-feature entries within a changelog update description. |
+| `fair2:next` | next | Orders sequential method sections, steps, or substeps. |
+| `fair2:nextTrue` | nextTrue | Conditional branch target taken when a StepCase condition holds. |
+| `fair2:otherInformation` | otherInformation | Miscellaneous notes within a changelog update description. |
+| `fair2:qualifiedUsage` | qualifiedUsage | Condition guarding a conditional method step (StepCase). |
 | `fair2:roleName` | roleName | Human-readable label for a contributor role. |
 | `fair2:statistics` | statistics | Links to computed descriptive statistics. |
-| `fair2:step` | step | Connects a MethodSection with its constituent Step items. |
+| `fair2:step` | step | Connects a Section with its constituent Step items. |
 | `fair2:store` | store | Indicates the storage location or repository endpoint for an asset. |
+| `fair2:substep` | substep | Connects a Step with its constituent Substep items. |
+| `fair2:unit` | unit | Unit of measurement for a field or variable. |
 | `fair2:variables` | variables | Lists variable or feature definitions referenced by an analysis or record set. |
 | `fair2:visualization` | visualization | Links to a visualization derived from the dataset or record set. |
 

--- a/docs/specification/schema.md
+++ b/docs/specification/schema.md
@@ -57,7 +57,7 @@
 | `schema:name` | `fair2s:TextShape` | `[1..∞]` | Yes |
 | `schema:spatialCoverage` | `fair2s:SpatialCoverageShape` | `[0..∞]` | No |
 | `schema:subjectOf` | `fair2s:CreativeWorkShape` | `[0..∞]` | No |
-| `schema:temporalCoverage` | `fair2s:TextShape` | `[0..∞]` | No |
+| `schema:temporalCoverage` | `fair2s:TextShape` (ISO 8601 pattern) | `[0..∞]` | No |
 | `schema:url` | `fair2s:IdentifierShape` | `[1..∞]` | Yes |
 | `schema:version` | `fair2s:TextShape` | `[1..∞]` | Yes |
 
@@ -87,7 +87,7 @@
 - **schema:name**: Dataset must include a name.
 - **schema:spatialCoverage**: Dataset may specify spatial coverage information.
 - **schema:subjectOf**: Dataset may reference CreativeWorks (e.g., landing page, sameAs links).
-- **schema:temporalCoverage**: Dataset may specify the temporal coverage (e.g., 1995–2023).
+- **schema:temporalCoverage**: Dataset may specify the temporal coverage as an ISO 8601 date or interval — a single date (`2008`), a closed interval (`1995-01-01/2023-12-31`), or an open-ended interval (`2013-12-19/..`). This format is required by Google Dataset Search; the shape enforces it with `sh:pattern`.
 - **schema:url**: Dataset must include its canonical landing-page URL.
 - **schema:version**: Dataset must specify its version.
 
@@ -98,13 +98,13 @@
 ## fair2s:DistributionShape
 | Property | Type | Cardinality | Mandatory |
 |---|---|---|---|
-| `cr:sha256` | `xsd:string` | `[1..∞]` | Yes |
+| `schema:sha256` | `xsd:string` | `[1..∞]` | Yes |
 | `schema:contentUrl` | `xsd:anyURI` | `[1..∞]` | Yes |
 | `schema:encodingFormat` | `xsd:string` | `[1..∞]` | Yes |
 
 <details><summary>Constraint notes</summary>
 
-- **cr:sha256**: Each distribution must have a SHA-256 checksum.
+- **schema:sha256**: Each distribution must have a SHA-256 checksum (`schema:sha256`, as expected by mlcroissant).
 - **schema:contentUrl**: Each distribution must have a content URL.
 - **schema:encodingFormat**: Each distribution must specify its encoding format.
 
@@ -213,6 +213,22 @@
 
 - **@id**: Each role must have an IRI identifier, typically from CRO or FAIR² namespace.
 - **rdfs:label**: Each role must have a human-readable label (e.g., DataCuration, Supervision).
+
+</details>
+
+
+## fair2s:CreativeWorkShape
+*Targets:* used via `schema:subjectOf`
+
+| Property | Type | Cardinality | Mandatory |
+|---|---|---|---|
+| `schema:name` | `xsd:string` | `[1..∞]` | Yes |
+| `schema:url` | `fair2s:IdentifierShape` | `[0..∞]` | No |
+
+<details><summary>Constraint notes</summary>
+
+- **schema:name**: The referenced creative work must have a name.
+- **schema:url**: It may carry a URL (e.g. the FAIR² specification it conforms to).
 
 </details>
 
@@ -329,6 +345,23 @@
 - **@id**: Domain entries should ideally reference a controlled vocabulary (e.g., Wikidata).
 - **prov:wasAttributedTo**: Each domain should be attributed to at least one Person (creator or expert).
 - **schema:name**: Each domain entry must include a name (e.g., 'Marine Biology').
+
+</details>
+
+
+## fair2s:ContactShape
+*Targets:* used via `prov:wasAttributedTo`
+
+| Property | Type | Cardinality | Mandatory |
+|---|---|---|---|
+| `schema:name` | `xsd:string` | `[1..∞]` | Yes |
+| `schema:identifier` | `fair2s:IdentifierShape` | `[0..∞]` | No |
+
+<details><summary>Constraint notes</summary>
+
+- A reusable shape for a contact (Person or Organization) attributed to a classification such as a domain.
+- **schema:name**: The contact must have a name.
+- **schema:identifier**: It may carry an identifier (e.g. an ORCID or ROR).
 
 </details>
 
@@ -538,13 +571,36 @@
 
 | Property | Type | Cardinality | Mandatory |
 |---|---|---|---|
-| `schema:geo` | `sh:BlankNodeOrIRI` | `[0..∞]` | No |
-| `schema:name` | `xsd:string` | `[1..∞]` | Yes |
+| `schema:name` | `xsd:string` | `[0..∞]` | No |
+| `schema:description` | `xsd:string` | `[0..∞]` | No |
+| `schema:identifier` | `fair2s:IdentifierShape` | `[0..∞]` | No |
+| `schema:geo` | `fair2s:GeoShapeShape` or `schema:GeoCoordinatesShape` | `[0..∞]` | No |
+| `schema:geoWithin` | `sh:BlankNodeOrIRI` | `[0..∞]` | No |
+| `schema:containsPlace` | `fair2s:SpatialCoverageShape` | `[0..∞]` | No |
 
 <details><summary>Constraint notes</summary>
 
-- **schema:geo**: Spatial coverage may include a geo reference.
-- **schema:name**: Spatial coverage must include a place name.
+- A `Place` may carry a name, description, and identifier.
+- **schema:geo**: a geometry, either a `GeoShape` (bounding box / polygon) or a `GeoCoordinates` point.
+- **schema:geoWithin**: an enclosing region.
+- **schema:containsPlace**: nested Places — the shape is recursive, modelling e.g. a bounding box → convex hull → individual sampling sites.
+
+</details>
+
+
+## fair2s:GeoShapeShape
+*Targets:* `schema:GeoShape`
+
+| Property | Type | Cardinality | Mandatory |
+|---|---|---|---|
+| `schema:box` | `xsd:string` | one geometry | Conditional |
+| `schema:polygon` | `xsd:string` | one geometry | Conditional |
+| `schema:line` | `xsd:string` | one geometry | Conditional |
+| `schema:circle` | `xsd:string` | one geometry | Conditional |
+
+<details><summary>Constraint notes</summary>
+
+- A `GeoShape` must declare **at least one** geometry (`box`, `polygon`, `line`, or `circle`).
 
 </details>
 

--- a/examples/example-1/borja2025.json
+++ b/examples/example-1/borja2025.json
@@ -1,8 +1,27 @@
 {
   "@context": {
     "@base": "https://sen.science/doi/10.71728/r1rj-f947/",
-    "@vocab": "https://fair2.ai/ns/",
     "@language": "en",
+    "@vocab": "https://schema.org/",
+    "cr": "http://mlcommons.org/croissant/",
+    "credit": "http://purl.org/credit/ontology#CREDIT_",
+    "cro": "http://purl.obolibrary.org/obo/CRO_",
+    "dct": "http://purl.org/dc/terms/",
+    "fair2": "https://fair2.ai/ns/",
+    "fair2s": "https://fair2.ai/shapes/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rai": "http://mlcommons.org/croissant/RAI/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "https://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "Activity": {
+      "@id": "prov:Activity"
+    },
+    "Article": {
+      "@id": "schema:Article"
+    },
     "Audience": {
       "@id": "fair2:Audience"
     },
@@ -12,11 +31,17 @@
     "Boolean": {
       "@id": "schema:Boolean"
     },
+    "Certification": {
+      "@id": "fair2:Certification"
+    },
     "ContributorRole": {
       "@id": "fair2:ContributorRole"
     },
     "CreativeWork": {
       "@id": "schema:CreativeWork"
+    },
+    "DataArchive": {
+      "@id": "fair2:DataArchive"
     },
     "DataArticle": {
       "@id": "fair2:DataArticle",
@@ -24,6 +49,9 @@
     },
     "DataDownload": {
       "@id": "schema:DataDownload"
+    },
+    "DataPortal": {
+      "@id": "fair2:DataPortal"
     },
     "Dataset": {
       "@id": "schema:Dataset"
@@ -37,11 +65,20 @@
     "DefinedTerm": {
       "@id": "schema:DefinedTerm"
     },
+    "DefinedTermSet": {
+      "@id": "schema:DefinedTermSet"
+    },
     "DescriptiveStatistics": {
       "@id": "fair2:DescriptiveStatistics"
     },
+    "DigitalDocument": {
+      "@id": "schema:DigitalDocument"
+    },
     "Duration": {
       "@id": "schema:Duration"
+    },
+    "Event": {
+      "@id": "schema:Event"
     },
     "ExperimentDataset": {
       "@id": "fair2:ExperimentDataset",
@@ -77,6 +114,13 @@
     "Number": {
       "@id": "schema:Number"
     },
+    "Offer": {
+      "@id": "schema:Offer"
+    },
+    "OpenDataArticleSection": {
+      "@id": "fair2:OpenDataArticleSection",
+      "@type": "schema:Text"
+    },
     "Organization": {
       "@id": "schema:Organization"
     },
@@ -88,6 +132,9 @@
     },
     "Place": {
       "@id": "schema:Place"
+    },
+    "Product": {
+      "@id": "schema:Product"
     },
     "PropertyValue": {
       "@id": "schema:PropertyValue"
@@ -104,6 +151,16 @@
     "ScholarlyArticle": {
       "@id": "schema:ScholarlyArticle"
     },
+    "Section": {
+      "@id": "fair2:Section",
+      "@type": "schema:HowToSection"
+    },
+    "SoftwareAgent": {
+      "@id": "prov:SoftwareAgent"
+    },
+    "SoftwareSourceCode": {
+      "@id": "schema:SoftwareSourceCode"
+    },
     "Step": {
       "@id": "fair2:Step",
       "@type": "schema:HowToStep"
@@ -113,10 +170,6 @@
     },
     "Substep": {
       "@id": "fair2:Substep"
-    },
-    "Section": {
-      "@id": "fair2:Section",
-      "@type": "schema:HowToSection"
     },
     "Text": {
       "@id": "schema:Text"
@@ -130,17 +183,26 @@
     "activities": {
       "@id": "fair2:activities"
     },
+    "address": {
+      "@id": "schema:address"
+    },
     "affiliation": {
       "@id": "schema:affiliation"
     },
     "algorithm": {
       "@id": "schema:algorithm"
     },
+    "alternateName": {
+      "@id": "schema:alternateName"
+    },
     "annotationsPerItem": {
       "@id": "rai:annotationsPerItem"
     },
     "annotatorDemographics": {
       "@id": "rai:annotatorDemographics"
+    },
+    "articleBody": {
+      "@id": "schema:articleBody"
     },
     "atLocation": {
       "@id": "schema:atLocation"
@@ -154,11 +216,32 @@
     "box": {
       "@id": "schema:box"
     },
+    "brand": {
+      "@id": "schema:brand"
+    },
+    "bugFixes": {
+      "@id": "fair2:bugFixes"
+    },
     "builds": {
       "@id": "fair2:builds"
     },
+    "certificationDocument": {
+      "@id": "fair2:certificationDocument"
+    },
+    "certificationScope": {
+      "@id": "fair2:certificationScope"
+    },
+    "certifiedBy": {
+      "@id": "fair2:certifiedBy"
+    },
+    "changeLog": {
+      "@id": "fair2:changeLog"
+    },
     "citation": {
       "@id": "schema:citation"
+    },
+    "citationKey": {
+      "@id": "fair2:citationKey"
     },
     "citeAs": {
       "@id": "cr:citeAs"
@@ -168,6 +251,9 @@
     },
     "conformsTo": {
       "@id": "dct:conformsTo"
+    },
+    "containsPlace": {
+      "@id": "schema:containsPlace"
     },
     "contentSize": {
       "@id": "schema:contentSize"
@@ -181,46 +267,8 @@
     "contributorRole": {
       "@id": "fair2:contributorRole"
     },
-    "cr": "http://mlcommons.org/croissant/",
-    "credit": "http://www.niso.org/publications/z39104-2022-credit#",
-    "dataArticle": {
-      "@id": "fair2:dataArticle"
-    },
-    "dataPortal": {
-      "@id": "fair2:dataPortal"
-    },
-    "dataArchive": {
-      "@id": "fair2:dataArchive"
-    },
-    "DataPortal": {
-      "@id": "fair2:DataPortal"
-    },
-    "DataArchive": {
-      "@id": "fair2:DataArchive"
-    },
-    "DigitalDocument": {
-      "@id": "schema:DigitalDocument"
-    },
-    "SoftwareSourceCode": {
-      "@id": "schema:SoftwareSourceCode"
-    },
-    "Activity": {
-      "@id": "prov:Activity"
-    },
-    "SoftwareAgent": {
-      "@id": "prov:SoftwareAgent"
-    },
-    "softwareVersion": {
-      "@id": "schema:softwareVersion"
-    },
-    "programmingLanguage": {
-      "@id": "schema:programmingLanguage"
-    },
-    "runtimePlatform": {
-      "@id": "schema:runtimePlatform"
-    },
-    "pagination": {
-      "@id": "schema:pagination"
+    "creator": {
+      "@id": "schema:creator"
     },
     "dataAnnotationAnalysis": {
       "@id": "rai:dataAnnotationAnalysis"
@@ -230,6 +278,12 @@
     },
     "dataAnnotationProtocol": {
       "@id": "rai:dataAnnotationProtocol"
+    },
+    "dataArchive": {
+      "@id": "fair2:dataArchive"
+    },
+    "dataArticle": {
+      "@id": "fair2:dataArticle"
     },
     "dataBiases": {
       "@id": "rai:dataBiases"
@@ -258,6 +312,9 @@
     "dataManipulationProtocol": {
       "@id": "rai:dataManipulationProtocol"
     },
+    "dataPortal": {
+      "@id": "fair2:dataPortal"
+    },
     "dataPreprocessingProtocol": {
       "@id": "rai:dataPreprocessingProtocol"
     },
@@ -277,10 +334,26 @@
     "dataset": {
       "@id": "fair2:dataset"
     },
-    "datePublished": {
-      "@id": "schema:datePublished"
+    "dateCreated": {
+      "@id": "schema:dateCreated",
+      "@type": "xsd:date"
     },
-    "dct": "http://purl.org/dc/terms/",
+    "dateIssued": {
+      "@id": "fair2:dateIssued",
+      "@type": "xsd:date"
+    },
+    "dateModified": {
+      "@id": "schema:dateModified",
+      "@type": "xsd:date"
+    },
+    "datePublished": {
+      "@id": "schema:datePublished",
+      "@type": "xsd:date"
+    },
+    "dateUpdated": {
+      "@id": "schema:dateUpdated",
+      "@type": "xsd:date"
+    },
     "definition": {
       "@id": "skos:definition"
     },
@@ -296,6 +369,9 @@
     "domain": {
       "@id": "fair2:domain"
     },
+    "email": {
+      "@id": "schema:email"
+    },
     "encoding": {
       "@id": "schema:encoding"
     },
@@ -305,18 +381,38 @@
     "extract": {
       "@id": "cr:extract"
     },
-    "fair2": "https://fair2.ai/ns/",
+    "fair2ComplianceLevel": {
+      "@id": "fair2:fair2ComplianceLevel"
+    },
+    "familyName": {
+      "@id": "schema:familyName"
+    },
     "field": {
       "@id": "cr:field"
     },
     "fileObject": {
       "@id": "cr:fileObject"
     },
+    "funder": {
+      "@id": "schema:funder"
+    },
     "funding": {
       "@id": "schema:funding"
     },
+    "fundingScheme": {
+      "@id": "schema:fundingScheme"
+    },
+    "generated": {
+      "@id": "fair2:generated"
+    },
     "geo": {
       "@id": "schema:geo"
+    },
+    "geoWithin": {
+      "@id": "schema:geoWithin"
+    },
+    "givenName": {
+      "@id": "schema:givenName"
     },
     "hadRole": {
       "@id": "prov:hadRole"
@@ -324,14 +420,44 @@
     "hasPart": {
       "@id": "schema:hasPart"
     },
+    "headline": {
+      "@id": "schema:headline"
+    },
+    "holdingArchive": {
+      "@id": "schema:holdingArchive"
+    },
+    "image": {
+      "@id": "schema:image"
+    },
+    "improvements": {
+      "@id": "fair2:improvements"
+    },
     "isBasedOn": {
       "@id": "schema:isBasedOn"
     },
+    "isExperimentRelated": {
+      "@id": "fair2:isExperimentRelated"
+    },
+    "keywords": {
+      "@id": "schema:keywords"
+    },
     "label": {
-      "@id": "label"
+      "@id": "rdfs:label"
+    },
+    "latitude": {
+      "@id": "schema:latitude"
     },
     "license": {
       "@id": "schema:license"
+    },
+    "location": {
+      "@id": "schema:location"
+    },
+    "logo": {
+      "@id": "schema:logo"
+    },
+    "longitude": {
+      "@id": "schema:longitude"
     },
     "machineAnnotationTools": {
       "@id": "rai:machineAnnotationTools"
@@ -339,38 +465,86 @@
     "manuscript": {
       "@id": "fair2:manuscript"
     },
+    "methodSection": {
+      "@id": "fair2:methodSection"
+    },
     "name": {
       "@id": "schema:name"
+    },
+    "newFeatures": {
+      "@id": "fair2:newFeatures"
+    },
+    "next": {
+      "@id": "fair2:next"
+    },
+    "nextTrue": {
+      "@id": "fair2:nextTrue"
     },
     "note": {
       "@id": "skos:note"
     },
+    "offers": {
+      "@id": "schema:offers"
+    },
+    "organizer": {
+      "@id": "schema:organizer"
+    },
+    "otherInformation": {
+      "@id": "fair2:otherInformation"
+    },
+    "pagination": {
+      "@id": "schema:pagination"
+    },
     "personalSensitiveInformation": {
       "@id": "rai:personalSensitiveInformation"
     },
-    "prov": "http://www.w3.org/ns/prov#",
+    "polygon": {
+      "@id": "schema:polygon"
+    },
+    "price": {
+      "@id": "schema:price"
+    },
+    "priceCurrency": {
+      "@id": "schema:priceCurrency"
+    },
+    "programmingLanguage": {
+      "@id": "schema:programmingLanguage"
+    },
+    "propertyID": {
+      "@id": "schema:propertyID"
+    },
     "publication": {
       "@id": "schema:publication"
     },
     "publisher": {
       "@id": "schema:publisher"
     },
-    "rai": "http://mlcommons.org/croissant/RAI/",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "qualifiedUsage": {
+      "@id": "fair2:qualifiedUsage"
+    },
     "recordSet": {
       "@id": "cr:recordSet"
     },
-    "schema": "https://schema.org/",
-    "sh": "http://www.w3.org/ns/shacl#",
-    "sha256": {
-      "@id": "cr:sha256"
+    "roleName": {
+      "@id": "fair2:roleName"
     },
-    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "runtimePlatform": {
+      "@id": "schema:runtimePlatform"
+    },
+    "sha256": {
+      "@id": "schema:sha256"
+    },
+    "softwareVersion": {
+      "@id": "schema:softwareVersion"
+    },
     "source": {
       "@id": "cr:source"
     },
     "spatialCoverage": {
       "@id": "schema:spatialCoverage"
+    },
+    "startDate": {
+      "@id": "schema:startDate"
     },
     "statistics": {
       "@id": "fair2:statistics"
@@ -381,6 +555,15 @@
     "store": {
       "@id": "fair2:store"
     },
+    "subjectOf": {
+      "@id": "schema:subjectOf"
+    },
+    "substep": {
+      "@id": "fair2:substep"
+    },
+    "symbol": {
+      "@id": "schema:symbol"
+    },
     "temporalCoverage": {
       "@id": "schema:temporalCoverage"
     },
@@ -390,21 +573,47 @@
     "unitCode": {
       "@id": "schema:unitCode"
     },
+    "url": {
+      "@id": "schema:url"
+    },
+    "used": {
+      "@id": "prov:used",
+      "@type": "@id"
+    },
     "value": {
       "@id": "schema:value"
+    },
+    "variable": {
+      "@id": "fair2:variable",
+      "@type": "schema:DefinedTermSet"
+    },
+    "variableMeasured": {
+      "@id": "schema:variableMeasured"
     },
     "variables": {
       "@id": "fair2:variables",
       "@type": "schema:DefinedTermSet"
     },
-    "visualization": {
-      "@id": "fair2:visualization"
+    "verificationEndpoint": {
+      "@id": "fair2:verificationEndpoint"
     },
     "version": {
       "@id": "schema:version"
     },
+    "visualization": {
+      "@id": "fair2:visualization"
+    },
+    "wasAssociatedWith": {
+      "@id": "prov:wasAssociatedWith"
+    },
+    "wasAttributedTo": {
+      "@id": "prov:wasAttributedTo"
+    },
     "wasDerivedFrom": {
       "@id": "prov:wasDerivedFrom"
+    },
+    "wasGeneratedBy": {
+      "@id": "prov:wasGeneratedBy"
     },
     "wasRevisionOf": {
       "@id": "prov:wasRevisionOf"
@@ -417,7 +626,7 @@
   },
   "@graph": [
     {
-      "@id": "https://sen.science/doi/10.71728/r1rj-f947",
+      "@id": "https://doi.org/10.71728/r1rj-f947",
       "@type": "Dataset",
       "creator": [
         {
@@ -796,8 +1005,7 @@
           "@type": "schema:UpdateAction",
           "datePublished": "2025-03-12",
           "wasRevisionOf": {
-            "@type": "Dataset",
-            "identifier": "https://sen.science/doi/10.71728/r1rj-f947",
+            "identifier": "https://doi.org/10.71728/r1rj-f947",
             "version": "1.0"
           },
           "schema:description": {
@@ -816,8 +1024,7 @@
           "@type": "schema:UpdateAction",
           "datePublished": "2025-11-19",
           "wasRevisionOf": {
-            "@type": "Dataset",
-            "identifier": "https://sen.science/doi/10.71728/r1rj-f947",
+            "identifier": "https://doi.org/10.71728/r1rj-f947",
             "version": "1.1"
           },
           "schema:description": {
@@ -1578,15 +1785,12 @@
         "Bay of Biscay"
       ],
       "license": "http://opendatacommons.org/licenses/by/1-0/",
-      "name": "Borja_2025_Marine_Biodiversity_and_Environmental_Data_Dataset",
+      "name": "Marine biodiversity and environmental data: an AI-ready, open dataset from the long term (1995–2023) monitoring network",
       "dataArticle": {
         "@id": "https://doi.org/10.3389/focsu.2024.1528837"
       },
-      "dataPortal": {
-        "@id": "https://sen.science"
-      },
       "dataArchive": {
-        "@id": "https://zenodo.org/communities/fair2-borja2025"
+        "@id": "https://doi.org/10.5281/zenodo.18326712"
       },
       "domain": {
         "@id": "https://www.wikidata.org/wiki/Q7173",
@@ -1601,10 +1805,7878 @@
       "temporalCoverage": "1995/2023",
       "spatialCoverage": {
         "@type": "Place",
-        "name": "Bay of Biscay, Spain",
+        "@id": "#bbox",
+        "name": "Basque coast monitoring network — bounding box",
+        "description": "Rectangular envelope of 714 sampling sites along the Basque coast, Bay of Biscay.",
         "geo": {
           "@type": "GeoShape",
-          "box": "43.2652775 -3.146574 43.5000106 -1.7620755"
+          "box": "43.2 -3.2 43.6 -1.7"
+        },
+        "containsPlace": {
+          "@type": "Place",
+          "@id": "#hull",
+          "name": "Basque coast monitoring network — convex hull",
+          "description": "Tight convex envelope of the sampling sites.",
+          "geo": {
+            "@type": "GeoShape",
+            "polygon": "43.351681 -3.146574 43.3304106 -3.1166272 43.2652775 -2.956775 43.2696264 -2.093446 43.342779 -1.7654182 43.3439585 -1.7620755 43.3703224 -1.7745241 43.391142 -1.7907362 43.3967365 -1.8021212 43.4534029 -1.9179517 43.5000106 -2.7998994 43.4370744 -2.9553061 43.3825769 -3.0819745 43.351681 -3.146574"
+          },
+          "containsPlace": [
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Embarcadero). High Tide. Surface",
+              "identifier": "E-A10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3198828,
+                "longitude": -2.4209732
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Errenteria). High Tide. Surface",
+              "identifier": "E-A5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3220738,
+                "longitude": -2.4433249
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Puerto). High Tide. Surface",
+              "identifier": "E-B10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4076261,
+                "longitude": -2.9462871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Abaniko). High Tide. Surface",
+              "identifier": "E-B5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3962679,
+                "longitude": -2.9241072
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Campo de fútbol). High Tide. Surface",
+              "identifier": "E-B7HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3979003,
+                "longitude": -2.9442087
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Amute). High Tide. Surface",
+              "identifier": "E-BI10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3522399,
+                "longitude": -1.7912869
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (Txingudi). High Tide. Surface",
+              "identifier": "E-BI20HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3697139,
+                "longitude": -1.7901006
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Behobia). High Tide. Surface",
+              "identifier": "E-BI5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3439585,
+                "longitude": -1.7620755
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Puente). High Tide. Surface",
+              "identifier": "E-D10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924654,
+                "longitude": -2.3571932
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Campo de fútbol). High Tide. Surface",
+              "identifier": "E-D5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2934033,
+                "longitude": -2.3638895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Molino). High Tide. Surface",
+              "identifier": "E-L10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360204,
+                "longitude": -2.4989305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Astillero). High Tide. Surface",
+              "identifier": "E-L5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3568706,
+                "longitude": -2.5047208
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente). High Tide. Surface",
+              "identifier": "E-M10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468658,
+                "longitude": -3.1215941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Muskiz (Petronor). High Tide. Surface",
+              "identifier": "E-M5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3321796,
+                "longitude": -3.1125476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bilbao (Puente de Deusto). High Tide. Surface",
+              "identifier": "E-N10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696547,
+                "longitude": -2.9390273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barakaldo (Puente de Rontegi). High Tide. Surface",
+              "identifier": "E-N15HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2950701,
+                "longitude": -2.9739759
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Leioa (Lamiako). High Tide. Surface",
+              "identifier": "E-N17HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155945,
+                "longitude": -2.9977186
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Interior. High Tide. Surface",
+              "identifier": "E-N20HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3382378,
+                "longitude": -3.0269801
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Exterior. High Tide. Surface",
+              "identifier": "E-N30HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3604102,
+                "longitude": -3.045304
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Puente de La Autopista). High Tide. Surface",
+              "identifier": "E-O10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.282646,
+                "longitude": -2.1316088
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Rampa). High Tide. Surface",
+              "identifier": "E-O5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758501,
+                "longitude": -2.1201703
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lezo. High Tide. Surface",
+              "identifier": "E-OI10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3227859,
+                "longitude": -1.9038327
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia de San Pedro (Dársena de Herrera). High Tide. Surface",
+              "identifier": "E-OI15HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223598,
+                "longitude": -1.9311091
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (San Pedro). High Tide. Surface",
+              "identifier": "E-OI20HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3263187,
+                "longitude": -1.9211971
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Murueta (Astillero). High Tide. Surface",
+              "identifier": "E-OK10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3646562,
+                "longitude": -2.6840717
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Sukarrieta (Txatxarramendi). High Tide. Surface",
+              "identifier": "E-OK20HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3936244,
+                "longitude": -2.6942934
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Forua (Salida de la Depuradora). High Tide. Surface",
+              "identifier": "E-OK5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405092,
+                "longitude": -2.6661725
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente Narrondo). High Tide. Surface",
+              "identifier": "E-U10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2963289,
+                "longitude": -2.2562599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Bedua). High Tide. Surface",
+              "identifier": "E-U5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2790753,
+                "longitude": -2.251984
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente del Ferrocarril). High Tide. Surface",
+              "identifier": "E-U8HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2919597,
+                "longitude": -2.2449599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Puente de Santa Catalina). High Tide. Surface",
+              "identifier": "E-UR10HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3170633,
+                "longitude": -1.9781998
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Loiola). High Tide. Surface",
+              "identifier": "E-UR5HS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3142354,
+                "longitude": -1.9691095
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Embarcadero). High Tide. Bottom",
+              "identifier": "E-A10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3198828,
+                "longitude": -2.4209732
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Errenteria). High Tide. Bottom",
+              "identifier": "E-A5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3220738,
+                "longitude": -2.4433249
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Puerto). High Tide. Bottom",
+              "identifier": "E-B10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4076261,
+                "longitude": -2.9462871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Abaniko). High Tide. Bottom",
+              "identifier": "E-B5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3962679,
+                "longitude": -2.9241072
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Campo de fútbol). High Tide. Bottom",
+              "identifier": "E-B7HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3979003,
+                "longitude": -2.9442087
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Amute). High Tide. Bottom",
+              "identifier": "E-BI10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3522399,
+                "longitude": -1.7912869
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (Txingudi). High Tide. Bottom",
+              "identifier": "E-BI20HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3697139,
+                "longitude": -1.7901006
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Behobia). High Tide. Bottom",
+              "identifier": "E-BI5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3439585,
+                "longitude": -1.7620755
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Puente). High Tide. Bottom",
+              "identifier": "E-D10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924654,
+                "longitude": -2.3571932
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Campo de fútbol). High Tide. Bottom",
+              "identifier": "E-D5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2934033,
+                "longitude": -2.3638895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Molino). High Tide. Bottom",
+              "identifier": "E-L10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360204,
+                "longitude": -2.4989305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Astillero). High Tide. Bottom",
+              "identifier": "E-L5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3568706,
+                "longitude": -2.5047208
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente). High Tide. Bottom",
+              "identifier": "E-M10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468658,
+                "longitude": -3.1215941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Muskiz (Petronor). High Tide. Bottom",
+              "identifier": "E-M5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3321796,
+                "longitude": -3.1125476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bilbao (Puente de Deusto). High Tide. Bottom",
+              "identifier": "E-N10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696547,
+                "longitude": -2.9390273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barakaldo (Puente de Rontegi). High Tide. Bottom",
+              "identifier": "E-N15HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2950701,
+                "longitude": -2.9739759
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Leioa (Lamiako). High Tide. Bottom",
+              "identifier": "E-N17HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155945,
+                "longitude": -2.9977186
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Interior. High Tide. Bottom",
+              "identifier": "E-N20HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3382378,
+                "longitude": -3.0269801
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Exterior. High Tide. Bottom",
+              "identifier": "E-N30HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3604102,
+                "longitude": -3.045304
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Puente de La Autopista). High Tide. Bottom",
+              "identifier": "E-O10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.282646,
+                "longitude": -2.1316088
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Rampa). High Tide. Bottom",
+              "identifier": "E-O5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758501,
+                "longitude": -2.1201703
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lezo. High Tide. Bottom",
+              "identifier": "E-OI10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3227859,
+                "longitude": -1.9038327
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia de San Pedro (Dársena de Herrera). High Tide. Bottom",
+              "identifier": "E-OI15HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223598,
+                "longitude": -1.9311091
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (San Pedro). High Tide. Bottom",
+              "identifier": "E-OI20HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3263187,
+                "longitude": -1.9211971
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Murueta (Astillero). High Tide. Bottom",
+              "identifier": "E-OK10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3646562,
+                "longitude": -2.6840717
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Sukarrieta (Txatxarramendi). High Tide. Bottom",
+              "identifier": "E-OK20HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3936244,
+                "longitude": -2.6942934
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Forua (Salida de la Depuradora). High Tide. Bottom",
+              "identifier": "E-OK5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405092,
+                "longitude": -2.6661725
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente Narrondo). High Tide. Bottom",
+              "identifier": "E-U10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2963289,
+                "longitude": -2.2562599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Bedua). High Tide. Bottom",
+              "identifier": "E-U5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2790753,
+                "longitude": -2.251984
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente del Ferrocarril). High Tide. Bottom",
+              "identifier": "E-U8HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2919597,
+                "longitude": -2.2449599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Puente de Santa Catalina). High Tide. Bottom",
+              "identifier": "E-UR10HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3170633,
+                "longitude": -1.9781998
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Loiola). High Tide. Bottom",
+              "identifier": "E-UR5HB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3142354,
+                "longitude": -1.9691095
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Embarcadero). Low Tide. Surface",
+              "identifier": "E-A10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3198828,
+                "longitude": -2.4209732
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Errenteria). Low Tide. Surface",
+              "identifier": "E-A5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3220738,
+                "longitude": -2.4433249
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Puerto). Low Tide. Surface",
+              "identifier": "E-B10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4076261,
+                "longitude": -2.9462871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Abaniko). Low Tide. Surface",
+              "identifier": "E-B5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3962679,
+                "longitude": -2.9241072
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Campo de fútbol). Low Tide. Surface",
+              "identifier": "E-B7LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3979003,
+                "longitude": -2.9442087
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Amute). Low Tide. Surface",
+              "identifier": "E-BI10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3522399,
+                "longitude": -1.7912869
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (Txingudi). Low Tide. Surface",
+              "identifier": "E-BI20LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3697139,
+                "longitude": -1.7901006
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Behobia). Low Tide. Surface",
+              "identifier": "E-BI5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3439585,
+                "longitude": -1.7620755
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Puente). Low Tide. Surface",
+              "identifier": "E-D10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924654,
+                "longitude": -2.3571932
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Campo de fútbol). Low Tide. Surface",
+              "identifier": "E-D5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2934033,
+                "longitude": -2.3638895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Molino). Low Tide. Surface",
+              "identifier": "E-L10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360204,
+                "longitude": -2.4989305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Astillero). Low Tide. Surface",
+              "identifier": "E-L5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3568706,
+                "longitude": -2.5047208
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente). Low Tide. Surface",
+              "identifier": "E-M10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468658,
+                "longitude": -3.1215941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Muskiz (Petronor). Low Tide. Surface",
+              "identifier": "E-M5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3321796,
+                "longitude": -3.1125476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bilbao (Puente de Deusto). Low Tide. Surface",
+              "identifier": "E-N10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696547,
+                "longitude": -2.9390273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barakaldo (Puente de Rontegi). Low Tide. Surface",
+              "identifier": "E-N15LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2950701,
+                "longitude": -2.9739759
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Leioa (Lamiako). Low Tide. Surface",
+              "identifier": "E-N17LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155945,
+                "longitude": -2.9977186
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Interior. Low Tide. Surface",
+              "identifier": "E-N20LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3382378,
+                "longitude": -3.0269801
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Exterior. Low Tide. Surface",
+              "identifier": "E-N30LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3604102,
+                "longitude": -3.045304
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Puente de La Autopista). Low Tide. Surface",
+              "identifier": "E-O10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.282646,
+                "longitude": -2.1316088
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Rampa). Low Tide. Surface",
+              "identifier": "E-O5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758501,
+                "longitude": -2.1201703
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lezo. Low Tide. Surface",
+              "identifier": "E-OI10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3227859,
+                "longitude": -1.9038327
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia de San Pedro (Dársena de Herrera). Low Tide. Surface",
+              "identifier": "E-OI15LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223598,
+                "longitude": -1.9311091
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (San Pedro). Low Tide. Surface",
+              "identifier": "E-OI20LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3263187,
+                "longitude": -1.9211971
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Murueta (Astillero). Low Tide. Surface",
+              "identifier": "E-OK10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3646562,
+                "longitude": -2.6840717
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Sukarrieta (Txatxarramendi). Low Tide. Surface",
+              "identifier": "E-OK20LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3936244,
+                "longitude": -2.6942934
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Forua (Salida de la Depuradora). Low Tide. Surface",
+              "identifier": "E-OK5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405092,
+                "longitude": -2.6661725
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente Narrondo). Low Tide. Surface",
+              "identifier": "E-U10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2963289,
+                "longitude": -2.2562599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Bedua). Low Tide. Surface",
+              "identifier": "E-U5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2790753,
+                "longitude": -2.251984
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente del Ferrocarril). Low Tide. Surface",
+              "identifier": "E-U8LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2919597,
+                "longitude": -2.2449599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Puente de Santa Catalina). Low Tide. Surface",
+              "identifier": "E-UR10LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3170633,
+                "longitude": -1.9781998
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Loiola). Low Tide. Surface",
+              "identifier": "E-UR5LS",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3142354,
+                "longitude": -1.9691095
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Embarcadero). Low Tide. Bottom",
+              "identifier": "E-A10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3198828,
+                "longitude": -2.4209732
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Errenteria). Low Tide. Bottom",
+              "identifier": "E-A5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3220738,
+                "longitude": -2.4433249
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Puerto). Low Tide. Bottom",
+              "identifier": "E-B10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4076261,
+                "longitude": -2.9462871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Abaniko). Low Tide. Bottom",
+              "identifier": "E-B5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3962679,
+                "longitude": -2.9241072
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Campo de fútbol). Low Tide. Bottom",
+              "identifier": "E-B7LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3979003,
+                "longitude": -2.9442087
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Amute). Low Tide. Bottom",
+              "identifier": "E-BI10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3522399,
+                "longitude": -1.7912869
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (Txingudi). Low Tide. Bottom",
+              "identifier": "E-BI20LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3697139,
+                "longitude": -1.7901006
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Behobia). Low Tide. Bottom",
+              "identifier": "E-BI5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3439585,
+                "longitude": -1.7620755
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Puente). Low Tide. Bottom",
+              "identifier": "E-D10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924654,
+                "longitude": -2.3571932
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Campo de fútbol). Low Tide. Bottom",
+              "identifier": "E-D5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2934033,
+                "longitude": -2.3638895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Molino). Low Tide. Bottom",
+              "identifier": "E-L10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360204,
+                "longitude": -2.4989305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Astillero). Low Tide. Bottom",
+              "identifier": "E-L5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3568706,
+                "longitude": -2.5047208
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente). Low Tide. Bottom",
+              "identifier": "E-M10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468658,
+                "longitude": -3.1215941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Muskiz (Petronor). Low Tide. Bottom",
+              "identifier": "E-M5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3321796,
+                "longitude": -3.1125476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bilbao (Puente de Deusto). Low Tide. Bottom",
+              "identifier": "E-N10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696547,
+                "longitude": -2.9390273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barakaldo (Puente de Rontegi). Low Tide. Bottom",
+              "identifier": "E-N15LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2950701,
+                "longitude": -2.9739759
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Leioa (Lamiako). Low Tide. Bottom",
+              "identifier": "E-N17LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155945,
+                "longitude": -2.9977186
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Interior. Low Tide. Bottom",
+              "identifier": "E-N20LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3382378,
+                "longitude": -3.0269801
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Exterior. Low Tide. Bottom",
+              "identifier": "E-N30LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3604102,
+                "longitude": -3.045304
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Puente de La Autopista). Low Tide. Bottom",
+              "identifier": "E-O10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.282646,
+                "longitude": -2.1316088
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Rampa). Low Tide. Bottom",
+              "identifier": "E-O5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758501,
+                "longitude": -2.1201703
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lezo. Low Tide. Bottom",
+              "identifier": "E-OI10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3227859,
+                "longitude": -1.9038327
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia de San Pedro (Dársena de Herrera). Low Tide. Bottom",
+              "identifier": "E-OI15LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223598,
+                "longitude": -1.9311091
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (San Pedro). Low Tide. Bottom",
+              "identifier": "E-OI20LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3263187,
+                "longitude": -1.9211971
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Murueta (Astillero). Low Tide. Bottom",
+              "identifier": "E-OK10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3646562,
+                "longitude": -2.6840717
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Sukarrieta (Txatxarramendi). Low Tide. Bottom",
+              "identifier": "E-OK20LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3936244,
+                "longitude": -2.6942934
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Forua (Salida de la Depuradora). Low Tide. Bottom",
+              "identifier": "E-OK5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405092,
+                "longitude": -2.6661725
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente Narrondo). Low Tide. Bottom",
+              "identifier": "E-U10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2963289,
+                "longitude": -2.2562599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Bedua). Low Tide. Bottom",
+              "identifier": "E-U5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2790753,
+                "longitude": -2.251984
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente del Ferrocarril). Low Tide. Bottom",
+              "identifier": "E-U8LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2919597,
+                "longitude": -2.2449599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Puente de Santa Catalina). Low Tide. Bottom",
+              "identifier": "E-UR10LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3170633,
+                "longitude": -1.9781998
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Loiola). Low Tide. Bottom",
+              "identifier": "E-UR5LB",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3142354,
+                "longitude": -1.9691095
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Ondarroa. Surface",
+              "identifier": "L-A10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3359057,
+                "longitude": -2.4024526
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Gorliz (Cabo Villano). Surface",
+              "identifier": "L-B10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4370744,
+                "longitude": -2.9553061
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Bakio. Surface",
+              "identifier": "L-B20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4474131,
+                "longitude": -2.8032985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Hondarribia. Surface",
+              "identifier": "L-BI10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3967365,
+                "longitude": -1.8021212
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Deba. Surface",
+              "identifier": "L-D10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.326575,
+                "longitude": -2.352455
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Elantxobe (Kai Arri). Surface",
+              "identifier": "L-L10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4025731,
+                "longitude": -2.5851273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Lekeitio. Surface",
+              "identifier": "L-L20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3729133,
+                "longitude": -2.4896299
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral del Abra (Frente al Superpuerto). Surface",
+              "identifier": "L-N10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3825769,
+                "longitude": -3.0819745
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Sopelana. Surface",
+              "identifier": "L-N20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3992447,
+                "longitude": -3.0206474
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Orio. Surface",
+              "identifier": "L-O10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3054038,
+                "longitude": -2.1356127
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Getaria. Surface",
+              "identifier": "L-O20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155734,
+                "longitude": -2.18011
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia. Surface",
+              "identifier": "L-OI10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3375628,
+                "longitude": -1.9324461
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia (Asabaratza). Surface",
+              "identifier": "L-OI20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3600653,
+                "longitude": -1.8917834
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mundaka. Surface",
+              "identifier": "L-OK10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.440908,
+                "longitude": -2.7016305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Oiartzun - Plataforma. Surface",
+              "identifier": "L-RF10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4534029,
+                "longitude": -1.9179517
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Deba - Plataforma. Surface",
+              "identifier": "L-RF20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.400003,
+                "longitude": -2.299894
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Butroe - Plataforma. Surface",
+              "identifier": "L-RF30S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.5000106,
+                "longitude": -2.7998994
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Zumaia. Surface",
+              "identifier": "L-U10S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.317238,
+                "longitude": -2.2426121
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mompás. Surface",
+              "identifier": "L-UR20S",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3389036,
+                "longitude": -1.9547765
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Ondarroa. Bottom",
+              "identifier": "L-A10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3359057,
+                "longitude": -2.4024526
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Gorliz (Cabo Villano). Bottom",
+              "identifier": "L-B10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4370744,
+                "longitude": -2.9553061
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Bakio. Bottom",
+              "identifier": "L-B20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4474131,
+                "longitude": -2.8032985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Hondarribia. Bottom",
+              "identifier": "L-BI10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3967365,
+                "longitude": -1.8021212
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Deba. Bottom",
+              "identifier": "L-D10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.326575,
+                "longitude": -2.352455
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Elantxobe (Kai Arri). Bottom",
+              "identifier": "L-L10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4025731,
+                "longitude": -2.5851273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Lekeitio. Bottom",
+              "identifier": "L-L20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3729133,
+                "longitude": -2.4896299
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral del Abra (Frente al Superpuerto). Bottom",
+              "identifier": "L-N10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3825769,
+                "longitude": -3.0819745
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Sopelana. Bottom",
+              "identifier": "L-N20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3992447,
+                "longitude": -3.0206474
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Orio. Bottom",
+              "identifier": "L-O10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3054038,
+                "longitude": -2.1356127
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Getaria. Bottom",
+              "identifier": "L-O20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155734,
+                "longitude": -2.18011
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia. Bottom",
+              "identifier": "L-OI10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3375628,
+                "longitude": -1.9324461
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia (Asabaratza). Bottom",
+              "identifier": "L-OI20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3600653,
+                "longitude": -1.8917834
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mundaka. Bottom",
+              "identifier": "L-OK10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.440908,
+                "longitude": -2.7016305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Oiartzun - Plataforma. Bottom",
+              "identifier": "L-RF10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4534029,
+                "longitude": -1.9179517
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Deba - Plataforma. Bottom",
+              "identifier": "L-RF20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.400003,
+                "longitude": -2.299894
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Butroe - Plataforma. Bottom",
+              "identifier": "L-RF30B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.5000106,
+                "longitude": -2.7998994
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Zumaia. Bottom",
+              "identifier": "L-U10B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.317238,
+                "longitude": -2.2426121
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mompás. Bottom",
+              "identifier": "L-UR20B",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3389036,
+                "longitude": -1.9547765
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Embarcadero)",
+              "identifier": "E-A10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3198828,
+                "longitude": -2.4209732
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Errenteria)",
+              "identifier": "E-A5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3220738,
+                "longitude": -2.4433249
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Puerto)",
+              "identifier": "E-B10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4076261,
+                "longitude": -2.9462871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Abaniko)",
+              "identifier": "E-B5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3962679,
+                "longitude": -2.9241072
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (Campo de fútbol)",
+              "identifier": "E-B7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3979003,
+                "longitude": -2.9442087
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Amute)",
+              "identifier": "E-BI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3522399,
+                "longitude": -1.7912869
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (Txingudi)",
+              "identifier": "E-BI20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3697139,
+                "longitude": -1.7901006
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Irun (Behobia)",
+              "identifier": "E-BI5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3439585,
+                "longitude": -1.7620755
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Puente)",
+              "identifier": "E-D10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924654,
+                "longitude": -2.3571932
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Campo de fútbol)",
+              "identifier": "E-D5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2934033,
+                "longitude": -2.3638895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Molino)",
+              "identifier": "E-L10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360204,
+                "longitude": -2.4989305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (Astillero)",
+              "identifier": "E-L5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3568706,
+                "longitude": -2.5047208
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente)",
+              "identifier": "E-M10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468658,
+                "longitude": -3.1215941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Muskiz (Petronor)",
+              "identifier": "E-M5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3321796,
+                "longitude": -3.1125476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bilbao (Puente de Deusto)",
+              "identifier": "E-N10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696547,
+                "longitude": -2.9390273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barakaldo (Puente de Rontegi)",
+              "identifier": "E-N15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2950701,
+                "longitude": -2.9739759
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Leioa (Lamiako)",
+              "identifier": "E-N17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155945,
+                "longitude": -2.9977186
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Interior",
+              "identifier": "E-N20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3382378,
+                "longitude": -3.0269801
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Abra Exterior",
+              "identifier": "E-N30",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3604102,
+                "longitude": -3.045304
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Puente de La Autopista)",
+              "identifier": "E-O10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.282646,
+                "longitude": -2.1316088
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (Rampa)",
+              "identifier": "E-O5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758501,
+                "longitude": -2.1201703
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lezo",
+              "identifier": "E-OI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3227859,
+                "longitude": -1.9038327
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia de San Pedro (Dársena de Herrera)",
+              "identifier": "E-OI15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223598,
+                "longitude": -1.9311091
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (San Pedro)",
+              "identifier": "E-OI20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3263187,
+                "longitude": -1.9211971
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Murueta (Astillero)",
+              "identifier": "E-OK10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3646562,
+                "longitude": -2.6840717
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Sukarrieta (Txatxarramendi)",
+              "identifier": "E-OK20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3936244,
+                "longitude": -2.6942934
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Forua (Salida de la Depuradora)",
+              "identifier": "E-OK5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405092,
+                "longitude": -2.6661725
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente Narrondo)",
+              "identifier": "E-U10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2963289,
+                "longitude": -2.2562599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Bedua)",
+              "identifier": "E-U5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2790753,
+                "longitude": -2.251984
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (Puente del Ferrocarril)",
+              "identifier": "E-U8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2919597,
+                "longitude": -2.2449599
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Puente de Santa Catalina)",
+              "identifier": "E-UR10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3170633,
+                "longitude": -1.9781998
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (Loiola)",
+              "identifier": "E-UR5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3142354,
+                "longitude": -1.9691095
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Ondarroa",
+              "identifier": "L-A10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3359057,
+                "longitude": -2.4024526
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Gorliz (Cabo Villano)",
+              "identifier": "L-B10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4370744,
+                "longitude": -2.9553061
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Bakio",
+              "identifier": "L-B20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4474131,
+                "longitude": -2.8032985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Hondarribia",
+              "identifier": "L-BI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3967365,
+                "longitude": -1.8021212
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Deba",
+              "identifier": "L-D10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.326575,
+                "longitude": -2.352455
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Elantxobe (Kai Arri)",
+              "identifier": "L-L10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4025731,
+                "longitude": -2.5851273
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Lekeitio",
+              "identifier": "L-L20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3729133,
+                "longitude": -2.4896299
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral del Abra (Frente al Superpuerto)",
+              "identifier": "L-N10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3825769,
+                "longitude": -3.0819745
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Sopelana",
+              "identifier": "L-N20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3992447,
+                "longitude": -3.0206474
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Orio",
+              "identifier": "L-O10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3054038,
+                "longitude": -2.1356127
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Getaria",
+              "identifier": "L-O20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3155734,
+                "longitude": -2.18011
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia",
+              "identifier": "L-OI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3375628,
+                "longitude": -1.9324461
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Pasaia (Asabaratza)",
+              "identifier": "L-OI20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3600653,
+                "longitude": -1.8917834
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mundaka",
+              "identifier": "L-OK10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.440908,
+                "longitude": -2.7016305
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Oiartzun - Plataforma",
+              "identifier": "L-RF10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4534029,
+                "longitude": -1.9179517
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Deba - Plataforma",
+              "identifier": "L-RF20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.400003,
+                "longitude": -2.299894
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral Butroe - Plataforma",
+              "identifier": "L-RF30",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.5000106,
+                "longitude": -2.7998994
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Zumaia",
+              "identifier": "L-U10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.317238,
+                "longitude": -2.2426121
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Mompás",
+              "identifier": "L-UR20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3389036,
+                "longitude": -1.9547765
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ondarroa (Moluscos)",
+              "identifier": "I-A10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3250088,
+                "longitude": -2.4178904
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Plentzia (desembocadura) (Moluscos)",
+              "identifier": "I-B10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4114365,
+                "longitude": -2.9495939
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Hondarribia (desembocadura) (Moluscos)",
+              "identifier": "I-BI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3690499,
+                "longitude": -1.7911753
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Mutriku (playa) (Moluscos)",
+              "identifier": "I-D10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3005619,
+                "longitude": -2.3542476
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lekeitio (puente) (Moluscos)",
+              "identifier": "I-L10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3605368,
+                "longitude": -2.4988413
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pobeña (puente) (Moluscos)",
+              "identifier": "I-M10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3473524,
+                "longitude": -3.1212372
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zierbena (Ibaizabal) (Moluscos)",
+              "identifier": "I-N10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3535388,
+                "longitude": -3.0798993
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Getxo (Ibaizabal) (Moluscos)",
+              "identifier": "I-N20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3405169,
+                "longitude": -3.0229962
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio (puente de la autopista) (Moluscos)",
+              "identifier": "I-O10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2833516,
+                "longitude": -2.1308592
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Pasaia (desembocadura) (Moluscos)",
+              "identifier": "I-OI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3327795,
+                "longitude": -1.9264733
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Mundaka (puerto) (Moluscos)",
+              "identifier": "I-OK10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4081197,
+                "longitude": -2.6969871
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Zumaia (desembocadura) (Moluscos)",
+              "identifier": "I-U10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3017362,
+                "longitude": -2.2500541
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Donostia (puente del Kursaal) (Moluscos)",
+              "identifier": "I-UR10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3244369,
+                "longitude": -1.9800989
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Arminza",
+              "identifier": "L-B15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4465802,
+                "longitude": -2.8774772
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Litoral de Tximistarri",
+              "identifier": "L-UR10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3280714,
+                "longitude": -2.0177813
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 01.Estuario Macroalgas",
+              "identifier": "M-EA1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3200421,
+                "longitude": -2.422205
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02.Estuario Macroalgas",
+              "identifier": "M-EA2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3201352,
+                "longitude": -2.4281855
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 03.Estuario Macroalgas",
+              "identifier": "M-EA3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3202673,
+                "longitude": -2.4311935
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 04.Estuario Macroalgas",
+              "identifier": "M-EA4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3188291,
+                "longitude": -2.4353507
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 05.Estuario Macroalgas",
+              "identifier": "M-EA5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3196209,
+                "longitude": -2.43522
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 06.Estuario Macroalgas",
+              "identifier": "M-EA6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3207261,
+                "longitude": -2.4365788
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 07.Estuario Macroalgas",
+              "identifier": "M-EA7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3214449,
+                "longitude": -2.4399267
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01.Estuario Macroalgas",
+              "identifier": "M-EB1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4068353,
+                "longitude": -2.9498447
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 10.Estuario Macroalgas",
+              "identifier": "M-EB10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.398102,
+                "longitude": -2.9199063
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 11.Estuario Macroalgas",
+              "identifier": "M-EB11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3912487,
+                "longitude": -2.9186806
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 12.Estuario Macroalgas",
+              "identifier": "M-EB12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3840122,
+                "longitude": -2.9232212
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 13.Estuario Macroalgas",
+              "identifier": "M-EB13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3812564,
+                "longitude": -2.9225951
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02.Estuario Macroalgas",
+              "identifier": "M-EB2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4028562,
+                "longitude": -2.9517622
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03.Estuario Macroalgas",
+              "identifier": "M-EB3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4028185,
+                "longitude": -2.9480573
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 04.Estuario Macroalgas",
+              "identifier": "M-EB4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4015021,
+                "longitude": -2.9443413
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 05.Estuario Macroalgas",
+              "identifier": "M-EB5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3982609,
+                "longitude": -2.9450234
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 06.Estuario Macroalgas",
+              "identifier": "M-EB6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3967373,
+                "longitude": -2.9414685
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 07.Estuario Macroalgas",
+              "identifier": "M-EB7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3948107,
+                "longitude": -2.9421495
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 08.Estuario Macroalgas",
+              "identifier": "M-EB8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3906636,
+                "longitude": -2.93293
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 09.Estuario Macroalgas",
+              "identifier": "M-EB9",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3959885,
+                "longitude": -2.9237124
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Estuario Macroalgas",
+              "identifier": "M-EBI1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3654934,
+                "longitude": -1.7903449
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 10. Estuario Macroalgas",
+              "identifier": "M-EBI10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.345457,
+                "longitude": -1.7791823
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 11. Estuario Macroalgas",
+              "identifier": "M-EBI11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3462155,
+                "longitude": -1.7810672
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 12. Estuario Macroalgas",
+              "identifier": "M-EBI12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.342779,
+                "longitude": -1.7654182
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 13. Estuario Macroalgas",
+              "identifier": "M-EBI13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3703224,
+                "longitude": -1.7745241
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 14. Estuario Macroalgas",
+              "identifier": "M-EBI14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3649689,
+                "longitude": -1.7723857
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 15. Estuario Macroalgas",
+              "identifier": "M-EBI15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.360023,
+                "longitude": -1.7771996
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 16. Estuario Macroalgas",
+              "identifier": "M-EBI16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3569692,
+                "longitude": -1.7829868
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 17. Estuario Macroalgas",
+              "identifier": "M-EBI17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3531472,
+                "longitude": -1.7859876
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 18. Estuario Macroalgas",
+              "identifier": "M-EBI18",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3485857,
+                "longitude": -1.7812542
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 19. Estuario Macroalgas",
+              "identifier": "M-EBI19",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3451851,
+                "longitude": -1.7764858
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Estuario Macroalgas",
+              "identifier": "M-EBI2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3595771,
+                "longitude": -1.7894506
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 20. Estuario Macroalgas",
+              "identifier": "M-EBI20",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3426346,
+                "longitude": -1.7678886
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 21. Estuario Macroalgas",
+              "identifier": "M-EBI21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351437,
+                "longitude": -1.8065786
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 22. Estuario Macroalgas",
+              "identifier": "M-EBI22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3477799,
+                "longitude": -1.8142383
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 03. Estuario Macroalgas",
+              "identifier": "M-EBI3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3567882,
+                "longitude": -1.7888396
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 04. Estuario Macroalgas",
+              "identifier": "M-EBI4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3498949,
+                "longitude": -1.7960468
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 05. Estuario Macroalgas",
+              "identifier": "M-EBI5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3501646,
+                "longitude": -1.7908839
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 06. Estuario Macroalgas",
+              "identifier": "M-EBI6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3442799,
+                "longitude": -1.7844864
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 07. Estuario Macroalgas",
+              "identifier": "M-EBI7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3419997,
+                "longitude": -1.7691352
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 08. Estuario Macroalgas",
+              "identifier": "M-EBI8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3440927,
+                "longitude": -1.7821214
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 09. Estuario Macroalgas",
+              "identifier": "M-EBI9",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3468942,
+                "longitude": -1.7830771
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Estuario Macroalgas",
+              "identifier": "M-ED1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2971977,
+                "longitude": -2.3564653
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Estuario Macroalgas",
+              "identifier": "M-ED2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2947377,
+                "longitude": -2.3561461
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 03. Estuario Macroalgas",
+              "identifier": "M-ED3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2920333,
+                "longitude": -2.3572101
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 04. Estuario Macroalgas",
+              "identifier": "M-ED4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2902805,
+                "longitude": -2.3577586
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 05. Estuario Macroalgas",
+              "identifier": "M-ED5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2889966,
+                "longitude": -2.3584255
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 05b. Estuario Macroalgas",
+              "identifier": "M-ED5b",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.289972,
+                "longitude": -2.3589576
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 06. Estuario Macroalgas",
+              "identifier": "M-ED6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2913279,
+                "longitude": -2.361495
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 07. Estuario Macroalgas",
+              "identifier": "M-ED7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2924493,
+                "longitude": -2.3672155
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01.Estuario Macroalgas",
+              "identifier": "M-EL1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3626976,
+                "longitude": -2.4987865
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02.Estuario Macroalgas",
+              "identifier": "M-EL2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.359148,
+                "longitude": -2.4983591
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03.Estuario Macroalgas",
+              "identifier": "M-EL3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3576794,
+                "longitude": -2.5022955
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 04.Estuario Macroalgas",
+              "identifier": "M-EL4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3573056,
+                "longitude": -2.501225
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 05.Estuario Macroalgas",
+              "identifier": "M-EL5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3563928,
+                "longitude": -2.504589
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 06.Estuario Macroalgas",
+              "identifier": "M-EL6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3537868,
+                "longitude": -2.5016733
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Estuario Macroalgas",
+              "identifier": "M-EM1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3456214,
+                "longitude": -3.1231832
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Estuario Macroalgas",
+              "identifier": "M-EM2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3453441,
+                "longitude": -3.1215293
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Estuario Macroalgas",
+              "identifier": "M-EM3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3417916,
+                "longitude": -3.1173646
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 04. Estuario Macroalgas",
+              "identifier": "M-EM4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3380328,
+                "longitude": -3.1122624
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Estuario Macroalgas",
+              "identifier": "M-EN1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3310346,
+                "longitude": -3.0253733
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Estuario Macroalgas",
+              "identifier": "M-EN2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3187277,
+                "longitude": -3.0092988
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Estuario Macroalgas",
+              "identifier": "M-EN3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3163148,
+                "longitude": -2.9964483
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Estuario Macroalgas",
+              "identifier": "M-EN4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3106405,
+                "longitude": -2.9815528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Estuario Macroalgas",
+              "identifier": "M-EN5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.304644,
+                "longitude": -2.9857468
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 06. Estuario Macroalgas",
+              "identifier": "M-EN6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3004738,
+                "longitude": -2.9786956
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 07. Estuario Macroalgas",
+              "identifier": "M-EN7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.293826,
+                "longitude": -2.9685277
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 08. Estuario Macroalgas",
+              "identifier": "M-EN8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2835976,
+                "longitude": -2.9714787
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 09. Estuario Macroalgas",
+              "identifier": "M-EN9",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2652775,
+                "longitude": -2.956775
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Estuario Macroalgas",
+              "identifier": "M-EO1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2883975,
+                "longitude": -2.1312928
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 10. Estuario Macroalgas",
+              "identifier": "M-EO10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2696264,
+                "longitude": -2.093446
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 11. Estuario Macroalgas",
+              "identifier": "M-EO11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758858,
+                "longitude": -2.0958794
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Estuario Macroalgas",
+              "identifier": "M-EO2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2765099,
+                "longitude": -2.1322753
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Estuario Macroalgas",
+              "identifier": "M-EO3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2731257,
+                "longitude": -2.1324713
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Estuario Macroalgas",
+              "identifier": "M-EO4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2749476,
+                "longitude": -2.1198999
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Estuario Macroalgas",
+              "identifier": "M-EO5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2735382,
+                "longitude": -2.1228038
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 06. Estuario Macroalgas",
+              "identifier": "M-EO6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2758713,
+                "longitude": -2.1124183
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 07. Estuario Macroalgas",
+              "identifier": "M-EO7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2727434,
+                "longitude": -2.1027654
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 08. Estuario Macroalgas",
+              "identifier": "M-EO8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2703614,
+                "longitude": -2.1010012
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 09. Estuario Macroalgas",
+              "identifier": "M-EO9",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2702269,
+                "longitude": -2.0976514
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Estuario Macroalgas",
+              "identifier": "M-EOI1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3290374,
+                "longitude": -1.9230362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Estuario Macroalgas",
+              "identifier": "M-EOI2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223631,
+                "longitude": -1.9295427
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 03. Estuario Macroalgas",
+              "identifier": "M-EOI3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3211497,
+                "longitude": -1.9154427
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 04. Estuario Macroalgas",
+              "identifier": "M-EOI4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3182635,
+                "longitude": -1.9158887
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 05. Estuario Macroalgas",
+              "identifier": "M-EOI5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3167562,
+                "longitude": -1.9032381
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01.Estuario Macroalgas",
+              "identifier": "M-EOK1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3888573,
+                "longitude": -2.6829953
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 10.Estuario Macroalgas",
+              "identifier": "M-EOK10",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3621546,
+                "longitude": -2.6750261
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02.Estuario Macroalgas",
+              "identifier": "M-EOK2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3934092,
+                "longitude": -2.6946278
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03.Estuario Macroalgas",
+              "identifier": "M-EOK3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3876389,
+                "longitude": -2.6885329
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04.Estuario Macroalgas",
+              "identifier": "M-EOK4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3845654,
+                "longitude": -2.6874499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05.Estuario Macroalgas",
+              "identifier": "M-EOK5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.376824,
+                "longitude": -2.6883661
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06.Estuario Macroalgas",
+              "identifier": "M-EOK6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3747157,
+                "longitude": -2.6846243
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 07.Estuario Macroalgas",
+              "identifier": "M-EOK7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3700636,
+                "longitude": -2.6760947
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 08.Estuario Macroalgas",
+              "identifier": "M-EOK8",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3672337,
+                "longitude": -2.6816392
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 09.Estuario Macroalgas",
+              "identifier": "M-EOK9",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3606083,
+                "longitude": -2.6790945
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01. Estuario Macroalgas",
+              "identifier": "M-EU1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2992644,
+                "longitude": -2.2534872
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Estuario Macroalgas",
+              "identifier": "M-EU2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2984096,
+                "longitude": -2.2508347
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 03. Estuario Macroalgas",
+              "identifier": "M-EU3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2948007,
+                "longitude": -2.2580414
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 04. Estuario Macroalgas",
+              "identifier": "M-EU4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917881,
+                "longitude": -2.2448757
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 05. Estuario Macroalgas",
+              "identifier": "M-EU5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2848887,
+                "longitude": -2.2486957
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 06. Estuario Macroalgas",
+              "identifier": "M-EU6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2806892,
+                "longitude": -2.2550701
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Estuario Macroalgas",
+              "identifier": "M-EUR1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3222495,
+                "longitude": -1.9791612
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Estuario Macroalgas",
+              "identifier": "M-EUR2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3192152,
+                "longitude": -1.978176
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Estuario Macroalgas",
+              "identifier": "M-EUR3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3144294,
+                "longitude": -1.9786878
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 04. Estuario Macroalgas",
+              "identifier": "M-EUR4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084945,
+                "longitude": -1.9775788
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 05. Estuario Macroalgas",
+              "identifier": "M-EUR5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3124363,
+                "longitude": -1.974319
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 06. Estuario Macroalgas",
+              "identifier": "M-EUR6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3130457,
+                "longitude": -1.9649986
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 07. Estuario Macroalgas",
+              "identifier": "M-EUR7",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3100191,
+                "longitude": -1.9648773
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LA11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3215044,
+                "longitude": -2.4122999
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LA12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3215044,
+                "longitude": -2.4122999
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LA13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3215044,
+                "longitude": -2.4122999
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LA14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3215044,
+                "longitude": -2.4122999
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LA21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LA210",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LA211",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LA212",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 13",
+              "identifier": "M-LA213",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LA22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LA23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LA24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LA25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LA26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LA27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LA28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LA29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3230751,
+                "longitude": -2.4112981
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LB11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LB12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LB13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LB14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LB15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LB16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4180365,
+                "longitude": -2.9490202
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LB21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LB210",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LB22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LB23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LB24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LB25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LB26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LB27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LB28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LB29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4181537,
+                "longitude": -2.9494895
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LB31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LB310",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LB32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LB33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LB34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LB35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LB36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LB37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LB38",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe Zona 03. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LB39",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4334643,
+                "longitude": -2.899559
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LBI11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LBI12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LBI13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LBI14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LBI15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LBI16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LBI17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3931766,
+                "longitude": -1.79582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LBI21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LBI210",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LBI211",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LBI212",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 13",
+              "identifier": "M-LBI213",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 14",
+              "identifier": "M-LBI214",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 15",
+              "identifier": "M-LBI215",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 16",
+              "identifier": "M-LBI216",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 17",
+              "identifier": "M-LBI217",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 18",
+              "identifier": "M-LBI218",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LBI22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LBI23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LBI24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LBI25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LBI26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LBI27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LBI28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LBI29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.391142,
+                "longitude": -1.7907362
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LD11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LD12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LD13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LD14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LD15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LD16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LD17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3028695,
+                "longitude": -2.3562699
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LD21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LD210",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LD211",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LD212",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 13",
+              "identifier": "M-LD213",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 14",
+              "identifier": "M-LD214",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LD22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LD23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LD24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LD25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LD26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LD27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LD28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LD29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3024359,
+                "longitude": -2.3449192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LL11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LL12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LL13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LL14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LL15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LL16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3668689,
+                "longitude": -2.4972341
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LL21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3648465,
+                "longitude": -2.4960042
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LL22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3648465,
+                "longitude": -2.4960042
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LL23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3648465,
+                "longitude": -2.4960042
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LL24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3648465,
+                "longitude": -2.4960042
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LL25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3648465,
+                "longitude": -2.4960042
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LL31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LL32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LL33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LL34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LL35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LL36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LL37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea Zona 03. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LL38",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3633326,
+                "longitude": -2.4916849
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LM11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LM110",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LM12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LM13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LM14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LM15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LM16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LM17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LM18",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 01. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LM19",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3490175,
+                "longitude": -3.1219192
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LM21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LM210",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LM211",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LM22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LM23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LM24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LM25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LM26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LM27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LM28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LM29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3526642,
+                "longitude": -3.1133258
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LM31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LM310",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LM311",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LM312",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 13",
+              "identifier": "M-LM313",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 14",
+              "identifier": "M-LM314",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LM32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LM33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LM34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LM35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LM36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LM37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LM38",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadún Zona 03. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LM39",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.351681,
+                "longitude": -3.146574
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LN11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3603986,
+                "longitude": -3.0515116
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LN12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3603986,
+                "longitude": -3.0515116
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LN13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3603986,
+                "longitude": -3.0515116
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LN14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3603986,
+                "longitude": -3.0515116
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LN15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3603986,
+                "longitude": -3.0515116
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 1a",
+              "identifier": "M-LN21a",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 1b",
+              "identifier": "M-LN21b",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 2a",
+              "identifier": "M-LN22a",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 2b",
+              "identifier": "M-LN22b",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LN23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LN24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LN25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3719749,
+                "longitude": -3.0374499
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LN31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LN32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LN33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LN34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LN35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LN36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LN37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 03. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LN38",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3574004,
+                "longitude": -3.1135198
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LN41",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LN410",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LN411",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LN412",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LN42",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LN43",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LN44",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LN45",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LN46",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LN47",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LN48",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 04. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LN49",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3803451,
+                "longitude": -3.0158881
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LN51",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LN52",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LN53",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LN54",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LN55",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LN56",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal Zona 05. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LN57",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3557078,
+                "longitude": -3.1132081
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LO11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LO12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LO13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LO14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LO15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LO16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2931759,
+                "longitude": -2.1320877
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LO21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LO22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LO23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LO24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LO25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LO26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LO27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LO28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2917453,
+                "longitude": -2.1251432
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LO31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 10",
+              "identifier": "M-LO310",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 11",
+              "identifier": "M-LO311",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 12",
+              "identifier": "M-LO312",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 13",
+              "identifier": "M-LO313",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 14",
+              "identifier": "M-LO314",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LO32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LO33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LO34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LO35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LO36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LO37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LO38",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 03. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LO39",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2941006,
+                "longitude": -2.1484825
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LO41",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LO42",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LO43",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LO44",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LO45",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LO46",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 04. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LO47",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2898449,
+                "longitude": -2.1274386
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LO51",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LO52",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LO53",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LO54",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LO55",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Orio Zona 05. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LO56",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.307584,
+                "longitude": -2.074777
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOI11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOI12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOI13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOI14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOI15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOI16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOI17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 01. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LOI18",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3322386,
+                "longitude": -1.9486985
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOI21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOI22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOI23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOI24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOI25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOI26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOI27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3357606,
+                "longitude": -1.927494
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOI31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3354825,
+                "longitude": -1.9314587
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOI32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3354825,
+                "longitude": -1.9314587
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOI33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3354825,
+                "longitude": -1.9314587
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOI34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3354825,
+                "longitude": -1.9314587
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOK17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4090005,
+                "longitude": -2.6963528
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOK27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LOK28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4037813,
+                "longitude": -2.6976385
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3945841,
+                "longitude": -2.6929056
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK41",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK42",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK43",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK44",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK45",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK46",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 04. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOK47",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4023519,
+                "longitude": -2.6851602
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK51",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK52",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK53",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK54",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK55",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK56",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOK57",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 05. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LOK58",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4105988,
+                "longitude": -2.6980863
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LOK61",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LOK62",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LOK63",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LOK64",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LOK65",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LOK66",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka Zona 06. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LOK67",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4120248,
+                "longitude": -2.6762294
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01a. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LU1a1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3037848,
+                "longitude": -2.2604474
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01a. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LU1a2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3037848,
+                "longitude": -2.2604474
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LU1b1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LU1b2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LU1b3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LU1b4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LU1b5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01b. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LU1b6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303637,
+                "longitude": -2.2598697
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LU1c1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LU1c2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LU1c3",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LU1c4",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LU1c5",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 01c. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LU1c6",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.303563,
+                "longitude": -2.2595623
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LU21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LU22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LU23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LU24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LU25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LU26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LU27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LU28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LU29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3084801,
+                "longitude": -2.239071
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LUR11",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LUR12",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LUR13",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LUR14",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LUR15",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LUR16",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LUR17",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 01. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LUR18",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3208656,
+                "longitude": -2.0154308
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LUR21",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LUR22",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LUR23",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LUR24",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LUR25",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LUR26",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LUR27",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 8",
+              "identifier": "M-LUR28",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 02. Litoral Macroalgas. Height: 9",
+              "identifier": "M-LUR29",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 1",
+              "identifier": "M-LUR31",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 2",
+              "identifier": "M-LUR32",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 3",
+              "identifier": "M-LUR33",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 4",
+              "identifier": "M-LUR34",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 5",
+              "identifier": "M-LUR35",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 6",
+              "identifier": "M-LUR36",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea Zona 03. Litoral Macroalgas. Height: 7",
+              "identifier": "M-LUR37",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3295506,
+                "longitude": -1.9719588
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai (Arrastre zona exterior estuario)",
+              "identifier": "AAE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3200121,
+                "longitude": -2.4198374
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai (Arrastre zona interior estuario)",
+              "identifier": "AAI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3203437,
+                "longitude": -2.4284549
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Artibai (Arrastre zona media estuario)",
+              "identifier": "AAM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3188221,
+                "longitude": -2.4249051
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe (Arrastre zona exterior estuario)",
+              "identifier": "ABE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.4006921,
+                "longitude": -2.945083
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe (Arrastre zona interior estuario)",
+              "identifier": "ABI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3913715,
+                "longitude": -2.9271507
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Butroe (Arrastre zona media estuario)",
+              "identifier": "ABM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.39317,
+                "longitude": -2.9384467
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Arrastre zona exterior estuario)",
+              "identifier": "ADE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2960597,
+                "longitude": -2.3558486
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Arrastre zona interior estuario)",
+              "identifier": "ADI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2913281,
+                "longitude": -2.361532
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Deba (Arrastre zona media estuario)",
+              "identifier": "ADM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2905865,
+                "longitude": -2.3577431
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea (Arrastre zona exterior estuario)",
+              "identifier": "ALE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3585777,
+                "longitude": -2.4997213
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea (Arrastre zona interior estuario)",
+              "identifier": "ALI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3553853,
+                "longitude": -2.5027585
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Lea (Arrastre zona media estuario)",
+              "identifier": "ALM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.356949,
+                "longitude": -2.5041279
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadun (Arrastre zona exterior estuario)",
+              "identifier": "AME",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.34246,
+                "longitude": -3.1153919
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadun (Arrastre zona interior estuario)",
+              "identifier": "AMI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3304106,
+                "longitude": -3.1166272
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Barbadun (Arrastre zona media estuario)",
+              "identifier": "AMM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3361604,
+                "longitude": -3.1117531
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal (Arrastre zona exterior estuario)",
+              "identifier": "ANE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3243095,
+                "longitude": -3.0182416
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal (Arrastre zona interior estuario)",
+              "identifier": "ANI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2888561,
+                "longitude": -2.9706504
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Ibaizabal (Arrastre zona media estuario)",
+              "identifier": "ANM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3129107,
+                "longitude": -2.9904061
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oria (Arrastre zona exterior estuario)",
+              "identifier": "AOE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2849592,
+                "longitude": -2.1291107
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oria (Arrastre zona interior estuario)",
+              "identifier": "AOI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2756116,
+                "longitude": -2.0964997
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka (Arrastre zona exterior estuario)",
+              "identifier": "AOKE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3850936,
+                "longitude": -2.686336
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka (Arrastre zona interior estuario)",
+              "identifier": "AOKI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3530827,
+                "longitude": -2.6703608
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oka (Arrastre zona media estuario)",
+              "identifier": "AOKM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3707337,
+                "longitude": -2.6806211
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oria (Arrastre zona media estuario)",
+              "identifier": "AOM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2753103,
+                "longitude": -2.1225689
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa (Arrastre zona exterior estuario)",
+              "identifier": "BIDE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3725777,
+                "longitude": -1.7909941
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa (Arrastre zona interior estuario_a)",
+              "identifier": "BIDI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3482547,
+                "longitude": -1.7814582
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa (Arrastre zona interior estuario_b)",
+              "identifier": "BIDIb",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3422605,
+                "longitude": -1.7707831
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Bidasoa (Arrastre zona media estuario)",
+              "identifier": "BIDM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3558484,
+                "longitude": -1.7876737
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun (Arrastre zona exterior estuario)",
+              "identifier": "OIAE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3306812,
+                "longitude": -1.9245243
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun (Arrastre zona interior 1 estuario Lezo)",
+              "identifier": "OIAI1",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3229141,
+                "longitude": -1.907814
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun (Arrastre zona interior 2 estuario Herrera)",
+              "identifier": "OIAI2",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3223947,
+                "longitude": -1.9290735
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Oiartzun (Arrastre zona media estuario)",
+              "identifier": "OIAM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3234543,
+                "longitude": -1.9201378
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola (Arrastre zona exterior estuario)",
+              "identifier": "UROE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3006911,
+                "longitude": -2.2513491
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola (Arrastre zona interior estuario)",
+              "identifier": "UROI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2808249,
+                "longitude": -2.255167
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urola (Arrastre zona media estuario)",
+              "identifier": "UROM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2937032,
+                "longitude": -2.2471819
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea (Arrastre zona exterior estuario)",
+              "identifier": "URUE",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3221042,
+                "longitude": -1.9790279
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea (Arrastre zona interior estuario)",
+              "identifier": "URUI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.312791,
+                "longitude": -1.9647193
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Urumea (Arrastre zona media estuario)",
+              "identifier": "URUM",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3086157,
+                "longitude": -1.9740256
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Nerbioi exterior (Arrastre zona exterior masa de agua)",
+              "identifier": "PV_GAL_ABRAINT",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3418063,
+                "longitude": -3.0257514
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Nerbioi interior (Arrastre zona exterior masa de agua)",
+              "identifier": "PV_GAL_LAMIAKO",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.3206279,
+                "longitude": -3.0060555
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Nerbioi interior (Arrastre zona interior masa de agua)",
+              "identifier": "PV_GAL_OLABEAGA",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2673307,
+                "longitude": -2.9572172
+              },
+              "description": "ES · Bay of Biscay"
+            },
+            {
+              "@type": "Place",
+              "name": "Nerbioi interior (Arrastre zona media masa de agua)",
+              "identifier": "PV_GAL_RONTEGI",
+              "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": 43.2969968,
+                "longitude": -2.9728039
+              },
+              "description": "ES · Bay of Biscay"
+            }
+          ]
         }
       },
       "accessRights": {
@@ -1615,7 +9687,7 @@
         "note": "By accessing this dataset, you acknowledge that it is made openly available under the stated license. You may use, share, and build upon it in accordance with the license terms, provided that you give appropriate attribution.",
         "url": "https://fair2.ai/spec/AgreementLevels/1"
       },
-      "method": [
+      "methodSection": [
         {
           "@type": "Section",
           "@id": "method-sections/4bd9f204-fd04-4c4c-9740-b530cdd9667f",
@@ -1640,11 +9712,6 @@
               "next": {
                 "@id": "steps/93e1e4e5-cb75-43ce-bb8b-ebcfd3c5b05d"
               },
-              "prov:used": [
-                {
-                  "@id": "source/readme"
-                }
-              ],
               "description": "The primary objective of this study was to assess environmental quality trends in the Basque Country’s marine ecosystems using long-term monitoring data from 1995 to 2023. Key areas of interest include examining water, sediment, and biological components to understand the impact of human pressures, such as industrial and urban discharges, as well as the effectiveness of management actions, like wastewater treatment. This dataset, gathered from 70 sampling stations across the Bay of Biscay, provides insights into environmental changes, supporting the overarching hypothesis that implemented management actions yield positive ecological effects."
             },
             {
@@ -2590,7 +10657,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Readme"
         },
         {
           "@id": "record-sets/METADATA",
@@ -3785,7 +11853,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Metadata"
         },
         {
           "@id": "record-sets/WATER",
@@ -5421,7 +13490,8 @@
                 "uri": "http://qudt.org/vocab/unit/MilliGM-PER-KiloGM"
               }
             }
-          ]
+          ],
+          "name": "Biota"
         },
         {
           "@id": "record-sets/SEDIMENTS",
@@ -6158,7 +14228,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Sediments"
         },
         {
           "@id": "record-sets/PHYTOPLANKTON",
@@ -7061,7 +15132,8 @@
                 "uri": "http://qudt.org/vocab/unit/CEL-PER-ML"
               }
             }
-          ]
+          ],
+          "name": "Phytoplankton"
         },
         {
           "@id": "record-sets/MACROALGAE",
@@ -7954,7 +16026,8 @@
                 "uri": "http://qudt.org/vocab/unit/PERCENT"
               }
             }
-          ]
+          ],
+          "name": "Macroalgae"
         },
         {
           "@id": "record-sets/INVERTEBRATES",
@@ -8847,7 +16920,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Invertebrates"
         },
         {
           "@id": "record-sets/FISH",
@@ -9750,7 +17824,8 @@
                 "uri": "http://qudt.org/vocab/unit/IND"
               }
             }
-          ]
+          ],
+          "name": "Fish"
         },
         {
           "@id": "record-sets/METHOD",
@@ -10122,7 +18197,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Method"
         },
         {
           "@id": "record-sets/AUTHORS",
@@ -10928,7 +19004,8 @@
                 "uri": "http://qudt.org/vocab/unit/UNITLESS"
               }
             }
-          ]
+          ],
+          "name": "Authors"
         },
         {
           "@id": "record-sets/ANALYTICAL_METHODS",
@@ -10998,7 +19075,8 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Subgroup classification of the analytical parameter."
             },
             {
               "@id": "record-sets/ANALYTICAL_METHODS/Alfanumeric+code",
@@ -11063,7 +19141,8 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Alphanumeric code identifying the parameter."
             },
             {
               "@id": "record-sets/ANALYTICAL_METHODS/Parameter",
@@ -11128,7 +19207,8 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Name of the measured parameter."
             },
             {
               "@id": "record-sets/ANALYTICAL_METHODS/Units",
@@ -11193,7 +19273,8 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Measurement units for the reported parameter."
             },
             {
               "@id": "record-sets/ANALYTICAL_METHODS/Analysis+method+code",
@@ -11258,7 +19339,8 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Code identifying the analytical method used."
             },
             {
               "@id": "record-sets/ANALYTICAL_METHODS/Analysis+method",
@@ -11323,9 +19405,11 @@
                     "programmingLanguage": "Python"
                   }
                 }
-              }
+              },
+              "description": "Name of the analytical method used to measure the parameter."
             }
-          ]
+          ],
+          "name": "Analytical Methods"
         }
       ],
       "subjectOf": {
@@ -11333,7 +19417,51 @@
         "name": "FAIR-Squared Specification",
         "url": "http://fair2.ai/spec/0.1.0-beta"
       },
-      "version": "1.2"
+      "version": "1.2",
+      "url": "https://sen.science/doi/10.71728/r1rj-f947"
+    },
+    {
+      "@id": "https://doi.org/10.3389/focsu.2024.1528837",
+      "@type": "DataArticle",
+      "name": "Marine biodiversity and environmental data: an AI-ready, open dataset from the long term (1995–2023) monitoring network",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Frontiers Media SA"
+      },
+      "publication": {
+        "@type": "Periodical",
+        "name": "Frontiers in Ocean Sustainability"
+      },
+      "datePublished": "2025-02-17",
+      "wasDerivedFrom": "https://doi.org/10.71728/r1rj-f947",
+      "version": "1.0",
+      "changeLog": []
+    },
+    {
+      "@id": "https://doi.org/10.5281/zenodo.18326712",
+      "@type": "DataArchive",
+      "name": "Borja 2025 — Marine Biodiversity and Environmental Data Archive",
+      "description": "Long-term archive of the FAIR² marine biodiversity and environmental dataset published by AZTI.",
+      "identifier": "https://doi.org/10.5281/zenodo.18326712",
+      "keywords": [
+        "marine biology",
+        "environmental monitoring",
+        "Basque Country"
+      ],
+      "holdingArchive": {
+        "@id": "https://zenodo.org",
+        "name": "Zenodo"
+      },
+      "author": {
+        "@id": "/authors/c1b96691-fbbf-4157-a2c5-e8fb78c799f1",
+        "@type": "Person",
+        "name": "Ángel Borja"
+      },
+      "version": "1.2",
+      "datePublished": "2025-02-17",
+      "dataset": "https://doi.org/10.71728/r1rj-f947",
+      "changeLog": [],
+      "url": "https://doi.org/10.5281/zenodo.18326712"
     },
     {
       "@type": "DigitalDocument",
@@ -11372,74 +19500,6 @@
       "identifier": "https://pandas.pydata.org/",
       "softwareVersion": "2.1.1",
       "programmingLanguage": "Python"
-    },
-    {
-      "@id": "https://doi.org/10.3389/focsu.2024.1528837",
-      "@type": "DataArticle",
-      "name": "Marine biodiversity and environmental data: an AI-ready, open dataset from the long term (1995–2023) monitoring network",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Frontiers Media SA"
-      },
-      "publication": {
-        "@type": "Periodical",
-        "name": "Frontiers in Ocean Sustainability"
-      },
-      "datePublished": "2025-02-17",
-      "wasDerivedFrom": "https://sen.science/doi/10.71728/r1rj-f947",
-      "version": "1.0",
-      "changeLog": []
-    },
-    {
-      "@id": "https://sen.science",
-      "@type": "DataPortal",
-      "name": "SEN.Science Open Data Portal",
-      "description": "Open data portal providing access to FAIR² compliant marine and environmental datasets.",
-      "identifier": "https://sen.science",
-      "url": "https://sen.science",
-      "keywords": [
-        "open data",
-        "marine science",
-        "FAIR²"
-      ],
-      "author": {
-        "@id": "/organizations/0d6a7bd5-95ee-4b5a-9ea9-35747624b353",
-        "@type": "Organization",
-        "name": "AZTI, Marine Research, Basque Research and Technology Alliance (BRTA)"
-      },
-      "version": "1.0",
-      "datePublished": "2025-02-17",
-      "dataset": {
-        "@id": "https://sen.science/doi/10.71728/r1rj-f947"
-      },
-      "changeLog": []
-    },
-    {
-      "@id": "https://zenodo.org/communities/fair2-borja2025",
-      "@type": "DataArchive",
-      "name": "Borja 2025 — Marine Biodiversity and Environmental Data Archive",
-      "description": "Long-term archive of the FAIR² marine biodiversity and environmental dataset published by AZTI.",
-      "identifier": "https://zenodo.org/communities/fair2-borja2025",
-      "keywords": [
-        "marine biology",
-        "environmental monitoring",
-        "Basque Country"
-      ],
-      "holdingArchive": {
-        "@id": "https://zenodo.org",
-        "name": "Zenodo"
-      },
-      "author": {
-        "@id": "/authors/c1b96691-fbbf-4157-a2c5-e8fb78c799f1",
-        "@type": "Person",
-        "name": "Ángel Borja"
-      },
-      "version": "1.2",
-      "datePublished": "2025-02-17",
-      "dataset": {
-        "@id": "https://sen.science/doi/10.71728/r1rj-f947"
-      },
-      "changeLog": []
     }
   ]
 }

--- a/shapes/json-ld/access_rights.json
+++ b/shapes/json-ld/access_rights.json
@@ -1,31 +1,32 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "schema": "https://schema.org/",
-        "fair2s": "https://fair2.ai/shapes/"
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "https://schema.org/",
+    "fair2s": "https://fair2.ai/shapes/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@id": "fair2s:AccessRightsShape",
+  "type": "sh:NodeShape",
+  "sh:targetClass": "schema:DefinedTerm",
+  "sh:nodeKind": "sh:IRI",
+  "sh:property": [
+    {
+      "sh:path": "schema:name",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
     },
-    "@id": "fair2s:AccessRightsShape",
-    "type": "sh:NodeShape",
-    "sh:targetClass": "schema:DefinedTerm",
-    "sh:nodeKind": "sh:IRI",
-    "sh:property": [
-        {
-            "sh:path": "schema:name",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:definition",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:note",
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:url",
-            "sh:nodeKind": "sh:IRI"
-        }
-    ]
+    {
+      "sh:path": "skos:definition",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
+    },
+    {
+      "sh:path": "skos:note",
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "schema:url",
+      "sh:node": "fair2s:IdentifierShape"
+    }
+  ]
 }

--- a/shapes/json-ld/common.json
+++ b/shapes/json-ld/common.json
@@ -3,17 +3,92 @@
         "sh": "http://www.w3.org/ns/shacl#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "schema": "https://schema.org/",
         "fair2s": "https://fair2.ai/shapes/"
     },
-    "@id": "fair2s:TextShape",
-    "@type": "sh:NodeShape",
-    "sh:or": [
+    "@graph": [
         {
-            "sh:datatype": "xsd:string"
+            "@id": "fair2s:TextShape",
+            "@type": "sh:NodeShape",
+            "sh:or": [
+                {
+                    "sh:datatype": "xsd:string"
+                },
+                {
+                    "sh:datatype": "rdf:langString"
+                }
+            ],
+            "sh:message": "Value must be a plain string (xsd:string) or a language-tagged string (rdf:langString)."
         },
         {
-            "sh:datatype": "rdf:langString"
+            "@id": "fair2s:IdentifierShape",
+            "@type": "sh:NodeShape",
+            "sh:or": [
+                {
+                    "sh:nodeKind": "sh:IRI"
+                },
+                {
+                    "sh:datatype": "xsd:string"
+                },
+                {
+                    "sh:datatype": "rdf:langString"
+                }
+            ],
+            "sh:message": "Identifier must be a valid IRI (URL) or a text string."
+        },
+        {
+            "@id": "fair2s:CreativeWorkShape",
+            "@type": "sh:NodeShape",
+            "sh:property": [
+                {
+                    "sh:path": "schema:name",
+                    "sh:minCount": 1,
+                    "sh:node": "fair2s:TextShape"
+                },
+                {
+                    "sh:path": "schema:url",
+                    "sh:node": "fair2s:IdentifierShape"
+                }
+            ]
+        },
+        {
+            "@id": "fair2s:GrantShape",
+            "@type": "sh:NodeShape",
+            "sh:property": [
+                {
+                    "sh:path": "schema:name",
+                    "sh:minCount": 1,
+                    "sh:node": "fair2s:TextShape"
+                },
+                {
+                    "sh:path": "schema:funder",
+                    "sh:node": "fair2s:PersonOrOrganizationShape"
+                },
+                {
+                    "sh:path": "schema:url",
+                    "sh:node": "fair2s:IdentifierShape"
+                },
+                {
+                    "sh:path": "schema:identifier",
+                    "sh:node": "fair2s:IdentifierShape"
+                }
+            ]
+        },
+        {
+            "@id": "fair2s:ContactShape",
+            "@type": "sh:NodeShape",
+            "sh:nodeKind": "sh:BlankNodeOrIRI",
+            "sh:property": [
+                {
+                    "sh:path": "schema:name",
+                    "sh:minCount": 1,
+                    "sh:node": "fair2s:TextShape"
+                },
+                {
+                    "sh:path": "schema:identifier",
+                    "sh:node": "fair2s:IdentifierShape"
+                }
+            ]
         }
-    ],
-    "sh:message": "Value must be a plain string (xsd:string) or a language-tagged string (rdf:langString)."
+    ]
 }

--- a/shapes/json-ld/coverage.json
+++ b/shapes/json-ld/coverage.json
@@ -2,30 +2,98 @@
     "@context": {
         "sh": "http://www.w3.org/ns/shacl#",
         "schema": "https://schema.org/",
+        "fair2": "https://fair2.ai/ns/",
+        "fair2s": "https://fair2.ai/shapes/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
-    "@id": "schema:PlaceShape",
-    "type": "sh:NodeShape",
-    "sh:property": [
+    "@graph": [
         {
-            "sh:path": "schema:geo",
-            "sh:minCount": 1,
-            "sh:node": {
-                "@id": "schema:GeoCoordinatesShape",
-                "type": "sh:NodeShape",
-                "sh:property": [
-                    {
-                        "sh:path": "schema:latitude",
+            "@id": "fair2s:SpatialCoverageShape",
+            "@type": "sh:NodeShape",
+            "sh:property": [
+                {
+                    "sh:path": "schema:name",
+                    "sh:node": "fair2s:TextShape"
+                },
+                {
+                    "sh:path": "schema:description",
+                    "sh:node": "fair2s:TextShape"
+                },
+                {
+                    "sh:path": "schema:identifier",
+                    "sh:node": "fair2s:IdentifierShape"
+                },
+                {
+                    "sh:path": "schema:geo",
+                    "sh:or": [
+                        {
+                            "sh:node": "fair2s:GeoShapeShape"
+                        },
+                        {
+                            "sh:node": "schema:GeoCoordinatesShape"
+                        }
+                    ]
+                },
+                {
+                    "sh:path": "schema:geoWithin",
+                    "sh:nodeKind": "sh:BlankNodeOrIRI"
+                },
+                {
+                    "sh:path": "schema:containsPlace",
+                    "sh:node": "fair2s:SpatialCoverageShape"
+                }
+            ]
+        },
+        {
+            "@id": "fair2s:GeoShapeShape",
+            "@type": "sh:NodeShape",
+            "sh:or": [
+                {
+                    "sh:property": {
+                        "sh:path": "schema:box",
                         "sh:minCount": 1,
-                        "sh:datatype": "xsd:float"
-                    },
-                    {
-                        "sh:path": "schema:longitude",
-                        "sh:minCount": 1,
-                        "sh:datatype": "xsd:float"
+                        "sh:node": "fair2s:TextShape"
                     }
-                ]
-            }
+                },
+                {
+                    "sh:property": {
+                        "sh:path": "schema:polygon",
+                        "sh:minCount": 1,
+                        "sh:node": "fair2s:TextShape"
+                    }
+                },
+                {
+                    "sh:property": {
+                        "sh:path": "schema:line",
+                        "sh:minCount": 1,
+                        "sh:node": "fair2s:TextShape"
+                    }
+                },
+                {
+                    "sh:property": {
+                        "sh:path": "schema:circle",
+                        "sh:minCount": 1,
+                        "sh:node": "fair2s:TextShape"
+                    }
+                }
+            ],
+            "sh:message": "A GeoShape must declare at least one geometry (box, polygon, line, or circle)."
+        },
+        {
+            "@id": "schema:GeoCoordinatesShape",
+            "@type": "sh:NodeShape",
+            "sh:property": [
+                {
+                    "sh:path": "schema:latitude",
+                    "sh:minCount": 1,
+                    "sh:datatype": "xsd:float"
+                },
+                {
+                    "sh:path": "schema:longitude",
+                    "sh:minCount": 1,
+                    "sh:datatype": "xsd:float"
+                }
+            ]
         }
     ]
 }

--- a/shapes/json-ld/data_article.json
+++ b/shapes/json-ld/data_article.json
@@ -1,41 +1,51 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "schema": "https://schema.org/",
-        "prov": "http://www.w3.org/ns/prov#",
-        "fair2": "https://fair2.ai/ns/",
-        "fair2s": "https://fair2.ai/shapes/"
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "https://schema.org/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "fair2": "https://fair2.ai/ns/",
+    "fair2s": "https://fair2.ai/shapes/"
+  },
+  "@id": "fair2s:ArticleShape",
+  "type": "sh:NodeShape",
+  "sh:targetClass": "schema:ScholarlyArticle",
+  "sh:nodeKind": "sh:IRI",
+  "sh:property": [
+    {
+      "sh:path": "schema:datePublished",
+      "sh:minCount": 1
     },
-    "@id": "fair2s:ArticleShape",
-    "type": "sh:NodeShape",
-    "sh:targetClass": "schema:ScholarlyArticle",
-    "sh:nodeKind": "sh:IRI",
-    "sh:property": [
-        {
-            "sh:path": "schema:headline",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:datePublished",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:publisher",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "prov:wasDerivedFrom",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "schema:version",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "fair2:changeLog",
-            "sh:node": "fair2s:UpdateActionShape"
-        }
-    ]
+    {
+      "sh:path": "schema:publisher",
+      "sh:minCount": 1
+    },
+    {
+      "sh:path": "prov:wasDerivedFrom",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:version",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "fair2:changeLog",
+      "sh:node": "fair2s:UpdateActionShape"
+    }
+  ],
+  "sh:or": [
+    {
+      "sh:property": {
+        "sh:path": "schema:headline",
+        "sh:minCount": 1
+      }
+    },
+    {
+      "sh:property": {
+        "sh:path": "schema:name",
+        "sh:minCount": 1
+      }
+    }
+  ]
 }

--- a/shapes/json-ld/data_portal.json
+++ b/shapes/json-ld/data_portal.json
@@ -1,70 +1,70 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "schema": "https://schema.org/",
-        "fair2": "https://fair2.ai/ns/",
-        "fair2s": "https://fair2.ai/shapes/",
-        "xsd": "http://www.w3.org/2001/XMLSchema#"
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "https://schema.org/",
+    "fair2": "https://fair2.ai/ns/",
+    "fair2s": "https://fair2.ai/shapes/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@id": "fair2s:DataPortalShape",
+  "@type": "sh:NodeShape",
+  "sh:targetClass": "fair2:DataPortal",
+  "sh:nodeKind": "sh:IRI",
+  "sh:property": [
+    {
+      "sh:path": "schema:name",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
     },
-    "@id": "fair2s:DataPortalShape",
-    "@type": "sh:NodeShape",
-    "sh:targetClass": "fair2:DataPortal",
-    "sh:nodeKind": "sh:IRI",
-    "sh:property": [
-        {
-            "sh:path": "schema:name",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:description",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:identifier",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "schema:keywords",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:url",
-            "sh:minCount": 1,
-            "sh:nodeKind": "sh:IRI"
-        },
-        {
-            "sh:path": "schema:author",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:PersonOrOrganizationShape"
-        },
-        {
-            "sh:path": "schema:version",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "fair2:changeLog",
-            "sh:node": "fair2s:UpdateActionShape"
-        },
-        {
-            "sh:path": "schema:dateCreated",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "schema:datePublished",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "schema:dateUpdated",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "fair2:dataset",
-            "sh:node": "fair2s:IdentifierShape"
-        }
-    ]
+    {
+      "sh:path": "schema:description",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "schema:identifier",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:keywords",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "schema:url",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:author",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:PersonOrOrganizationShape"
+    },
+    {
+      "sh:path": "schema:version",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "fair2:changeLog",
+      "sh:node": "fair2s:UpdateActionShape"
+    },
+    {
+      "sh:path": "schema:dateCreated",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "schema:datePublished",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "schema:dateUpdated",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "fair2:dataset",
+      "sh:node": "fair2s:IdentifierShape"
+    }
+  ]
 }

--- a/shapes/json-ld/dataset.json
+++ b/shapes/json-ld/dataset.json
@@ -1,141 +1,143 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "dct": "http://purl.org/dc/terms/",
-        "schema": "https://schema.org/",
-        "cr": "http://mlcommons.org/croissant/",
-        "fair2": "https://fair2.ai/ns/",
-        "fair2s": "https://fair2.ai/shapes/",
-        "xsd": "http://www.w3.org/2001/XMLSchema#"
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "dct": "http://purl.org/dc/terms/",
+    "schema": "https://schema.org/",
+    "cr": "http://mlcommons.org/croissant/",
+    "fair2": "https://fair2.ai/ns/",
+    "fair2s": "https://fair2.ai/shapes/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@id": "fair2s:DatasetShape",
+  "type": "sh:NodeShape",
+  "sh:targetClass": "schema:Dataset",
+  "sh:nodeKind": "sh:IRI",
+  "sh:property": [
+    {
+      "sh:path": "schema:name",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1,
+      "sh:message": "Name must be a string or a language-tagged string."
     },
-    "@id": "fair2s:DatasetShape",
-    "type": "sh:NodeShape",
-    "sh:targetClass": "schema:Dataset",
-    "sh:nodeKind": "sh:IRI",
-    "sh:property": [
-        {
-            "sh:path": "schema:name",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1,
-            "sh:message": "Name must be a string or a language-tagged string."
-        },
-        {
-            "sh:path": "schema:description",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:identifier",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "schema:version",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:license",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "schema:url",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "schema:keywords",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "dct:conformsTo",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:IdentifierShape"
-        },
-        {
-            "sh:path": "cr:citeAs",
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "fair2:methodSection",
-            "sh:node": "fair2s:MethodSectionShape"
-        },
-        {
-            "sh:path": "cr:recordSet",
-            "sh:node": "fair2s:RecordSetShape"
-        },
-        {
-            "sh:path": "schema:creator",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:PersonOrOrganizationShape"
-        },
-        {
-            "sh:path": "schema:contributor",
-            "sh:node": "fair2s:ContributorShape"
-        },
-        {
-            "sh:path": "schema:funding",
-            "sh:node": "fair2s:GrantShape"
-        },
-        {
-            "sh:path": "schema:temporalCoverage",
-            "sh:node": "fair2s:TextShape"
-        },
-        {
-            "sh:path": "schema:spatialCoverage",
-            "sh:node": "fair2s:SpatialCoverageShape"
-        },
-        {
-            "sh:path": "schema:distribution",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:DistributionShape"
-        },
-        {
-            "sh:path": "schema:dateCreated",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "schema:datePublished",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "schema:dateUpdated",
-            "sh:datatype": "xsd:date"
-        },
-        {
-            "sh:path": "fair2:changeLog",
-            "sh:node": "fair2s:UpdateActionShape"
-        },
-        {
-            "sh:path": "schema:subjectOf",
-            "sh:node": "fair2s:CreativeWorkShape"
-        },
-        {
-            "sh:path": "fair2:domain",
-            "sh:node": "fair2s:DomainShape"
-        },
-        {
-            "sh:path": "fair2s:socialMedia",
-            "sh:node": "fair2s:SocialMediaShape"
-        },
-        {
-            "sh:path": "schema:accessRights",
-            "sh:node": "fair2s:AccessRightsShape"
-        },
-        {
-            "sh:path": "fair2:dataArticle",
-            "sh:minCount": 1,
-            "sh:node": "fair2s:ArticleShape"
-        },
-        {
-            "sh:path": "fair2:dataPortal",
-            "sh:node": "fair2s:DataPortalShape"
-        },
-        {
-            "sh:path": "fair2:dataArchive",
-            "sh:node": "fair2s:DataArchiveShape"
-        }
-    ]
+    {
+      "sh:path": "schema:description",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "schema:identifier",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:version",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "schema:license",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:url",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "schema:keywords",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "dct:conformsTo",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:IdentifierShape"
+    },
+    {
+      "sh:path": "cr:citeAs",
+      "sh:node": "fair2s:TextShape"
+    },
+    {
+      "sh:path": "fair2:methodSection",
+      "sh:node": "fair2s:MethodSectionShape"
+    },
+    {
+      "sh:path": "cr:recordSet",
+      "sh:node": "fair2s:RecordSetShape"
+    },
+    {
+      "sh:path": "schema:creator",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:PersonOrOrganizationShape"
+    },
+    {
+      "sh:path": "schema:contributor",
+      "sh:node": "fair2s:ContributorShape"
+    },
+    {
+      "sh:path": "schema:funding",
+      "sh:node": "fair2s:GrantShape"
+    },
+    {
+      "sh:path": "schema:temporalCoverage",
+      "sh:node": "fair2s:TextShape",
+      "sh:pattern": "^(\\d{4}(-\\d{2}(-\\d{2})?)?)(/(\\d{4}(-\\d{2}(-\\d{2})?)?|\\.\\.))?$",
+      "sh:message": "temporalCoverage must be an ISO 8601 date or interval (e.g. '1995-01-01/2023-12-31') for Google Dataset Search compliance."
+    },
+    {
+      "sh:path": "schema:spatialCoverage",
+      "sh:node": "fair2s:SpatialCoverageShape"
+    },
+    {
+      "sh:path": "schema:distribution",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:DistributionShape"
+    },
+    {
+      "sh:path": "schema:dateCreated",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "schema:datePublished",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "schema:dateUpdated",
+      "sh:datatype": "xsd:date"
+    },
+    {
+      "sh:path": "fair2:changeLog",
+      "sh:node": "fair2s:UpdateActionShape"
+    },
+    {
+      "sh:path": "schema:subjectOf",
+      "sh:node": "fair2s:CreativeWorkShape"
+    },
+    {
+      "sh:path": "fair2:domain",
+      "sh:node": "fair2s:DomainShape"
+    },
+    {
+      "sh:path": "fair2s:socialMedia",
+      "sh:node": "fair2s:SocialMediaShape"
+    },
+    {
+      "sh:path": "schema:accessRights",
+      "sh:node": "fair2s:AccessRightsShape"
+    },
+    {
+      "sh:path": "fair2:dataArticle",
+      "sh:minCount": 1,
+      "sh:node": "fair2s:ArticleShape"
+    },
+    {
+      "sh:path": "fair2:dataPortal",
+      "sh:node": "fair2s:DataPortalShape"
+    },
+    {
+      "sh:path": "fair2:dataArchive",
+      "sh:node": "fair2s:DataArchiveShape"
+    }
+  ]
 }

--- a/shapes/json-ld/distribution.json
+++ b/shapes/json-ld/distribution.json
@@ -1,39 +1,39 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "schema": "https://schema.org/",
-        "cr": "http://mlcommons.org/croissant/",
-        "fair2s": "https://fair2.ai/shapes/"
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "https://schema.org/",
+    "cr": "http://mlcommons.org/croissant/",
+    "fair2s": "https://fair2.ai/shapes/"
+  },
+  "@id": "schema:DistributionShape",
+  "type": "sh:NodeShape",
+  "sh:targetClass": "cr:FileObject",
+  "sh:nodeKind": "sh:IRI",
+  "sh:property": [
+    {
+      "sh:path": "schema:name",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
     },
-    "@id": "schema:DistributionShape",
-    "type": "sh:NodeShape",
-    "sh:targetClass": "cr:FileObject",
-    "sh:nodeKind": "sh:IRI",
-    "sh:property": [
-        {
-            "sh:path": "schema:name",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:contentUrl",
-            "sh:node": "fair2s:IdentifierShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:encodingFormat",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "schema:contentSize",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        },
-        {
-            "sh:path": "cr:sha256",
-            "sh:node": "fair2s:TextShape",
-            "sh:minCount": 1
-        }
-    ]
+    {
+      "sh:path": "schema:contentUrl",
+      "sh:node": "fair2s:IdentifierShape",
+      "sh:minCount": 1
+    },
+    {
+      "sh:path": "schema:encodingFormat",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
+    },
+    {
+      "sh:path": "schema:contentSize",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
+    },
+    {
+      "sh:path": "schema:sha256",
+      "sh:node": "fair2s:TextShape",
+      "sh:minCount": 1
+    }
+  ]
 }

--- a/shapes/json-ld/provenance.json
+++ b/shapes/json-ld/provenance.json
@@ -1,127 +1,127 @@
 {
-    "@context": {
-        "sh": "http://www.w3.org/ns/shacl#",
-        "schema": "https://schema.org/",
-        "prov": "http://www.w3.org/ns/prov#",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "fair2s": "https://fair2.ai/shapes/",
-        "xsd": "http://www.w3.org/2001/XMLSchema#"
-    },
-    "@graph": [
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "https://schema.org/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "fair2s": "https://fair2.ai/shapes/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "fair2s:DigitalDocumentShape",
+      "@type": "sh:NodeShape",
+      "sh:targetClass": "schema:DigitalDocument",
+      "sh:nodeKind": "sh:IRI",
+      "sh:property": [
         {
-            "@id": "fair2s:DigitalDocumentShape",
-            "@type": "sh:NodeShape",
-            "sh:targetClass": "schema:DigitalDocument",
-            "sh:nodeKind": "sh:IRI",
-            "sh:property": [
-                {
-                    "sh:path": "schema:name",
-                    "sh:minCount": 1,
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:pagination",
-                    "sh:node": "fair2s:TextShape",
-                    "sh:description": "Relative file path to the document within the dataset package."
-                },
-                {
-                    "sh:path": "schema:encodingFormat",
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:url",
-                    "sh:nodeKind": "sh:IRI"
-                }
-            ]
+          "sh:path": "schema:name",
+          "sh:minCount": 1,
+          "sh:node": "fair2s:TextShape"
         },
         {
-            "@id": "fair2s:SoftwareSourceCodeShape",
-            "@type": "sh:NodeShape",
-            "sh:targetClass": "schema:SoftwareSourceCode",
-            "sh:nodeKind": "sh:IRI",
-            "sh:property": [
-                {
-                    "sh:path": "schema:name",
-                    "sh:minCount": 1,
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:identifier",
-                    "sh:node": "fair2s:TextShape",
-                    "sh:description": "Relative path or persistent identifier for the script."
-                },
-                {
-                    "sh:path": "schema:encodingFormat",
-                    "sh:node": "fair2s:TextShape",
-                    "sh:description": "MIME type of the source file (e.g., text/x-python)."
-                },
-                {
-                    "sh:path": "schema:url",
-                    "sh:nodeKind": "sh:IRI"
-                },
-                {
-                    "sh:path": "schema:programmingLanguage",
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:runtimePlatform",
-                    "sh:node": "fair2s:TextShape",
-                    "sh:description": "Runtime environment (e.g., Python 3.11, R 4.3)."
-                }
-            ]
+          "sh:path": "schema:pagination",
+          "sh:node": "fair2s:TextShape",
+          "sh:description": "Relative file path to the document within the dataset package."
         },
         {
-            "@id": "fair2s:ActivityShape",
-            "@type": "sh:NodeShape",
-            "sh:targetClass": "prov:Activity",
-            "sh:nodeKind": "sh:IRI",
-            "sh:property": [
-                {
-                    "sh:path": "rdfs:label",
-                    "sh:minCount": 1,
-                    "sh:node": "fair2s:TextShape",
-                    "sh:description": "Human-readable name for the activity."
-                },
-                {
-                    "sh:path": "prov:wasAssociatedWith",
-                    "sh:nodeKind": "sh:IRI",
-                    "sh:description": "The agent responsible for this activity."
-                },
-                {
-                    "sh:path": "schema:startTime",
-                    "sh:datatype": "xsd:dateTime"
-                },
-                {
-                    "sh:path": "schema:endTime",
-                    "sh:datatype": "xsd:dateTime"
-                }
-            ]
+          "sh:path": "schema:encodingFormat",
+          "sh:node": "fair2s:TextShape"
         },
         {
-            "@id": "fair2s:SoftwareAgentShape",
-            "@type": "sh:NodeShape",
-            "sh:targetClass": "prov:SoftwareAgent",
-            "sh:nodeKind": "sh:IRI",
-            "sh:property": [
-                {
-                    "sh:path": "schema:name",
-                    "sh:minCount": 1,
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:identifier",
-                    "sh:node": "fair2s:IdentifierShape",
-                    "sh:description": "Persistent identifier or homepage URL for the software."
-                },
-                {
-                    "sh:path": "schema:softwareVersion",
-                    "sh:node": "fair2s:TextShape"
-                },
-                {
-                    "sh:path": "schema:programmingLanguage",
-                    "sh:node": "fair2s:TextShape"
-                }
-            ]
+          "sh:path": "schema:url",
+          "sh:node": "fair2s:IdentifierShape"
         }
-    ]
+      ]
+    },
+    {
+      "@id": "fair2s:SoftwareSourceCodeShape",
+      "@type": "sh:NodeShape",
+      "sh:targetClass": "schema:SoftwareSourceCode",
+      "sh:nodeKind": "sh:IRI",
+      "sh:property": [
+        {
+          "sh:path": "schema:name",
+          "sh:minCount": 1,
+          "sh:node": "fair2s:TextShape"
+        },
+        {
+          "sh:path": "schema:identifier",
+          "sh:node": "fair2s:TextShape",
+          "sh:description": "Relative path or persistent identifier for the script."
+        },
+        {
+          "sh:path": "schema:encodingFormat",
+          "sh:node": "fair2s:TextShape",
+          "sh:description": "MIME type of the source file (e.g., text/x-python)."
+        },
+        {
+          "sh:path": "schema:url",
+          "sh:node": "fair2s:IdentifierShape"
+        },
+        {
+          "sh:path": "schema:programmingLanguage",
+          "sh:node": "fair2s:TextShape"
+        },
+        {
+          "sh:path": "schema:runtimePlatform",
+          "sh:node": "fair2s:TextShape",
+          "sh:description": "Runtime environment (e.g., Python 3.11, R 4.3)."
+        }
+      ]
+    },
+    {
+      "@id": "fair2s:ActivityShape",
+      "@type": "sh:NodeShape",
+      "sh:targetClass": "prov:Activity",
+      "sh:nodeKind": "sh:BlankNodeOrIRI",
+      "sh:property": [
+        {
+          "sh:path": "rdfs:label",
+          "sh:minCount": 1,
+          "sh:node": "fair2s:TextShape",
+          "sh:description": "Human-readable name for the activity."
+        },
+        {
+          "sh:path": "prov:wasAssociatedWith",
+          "sh:nodeKind": "sh:BlankNodeOrIRI",
+          "sh:description": "The agent responsible for this activity."
+        },
+        {
+          "sh:path": "schema:startTime",
+          "sh:datatype": "xsd:dateTime"
+        },
+        {
+          "sh:path": "schema:endTime",
+          "sh:datatype": "xsd:dateTime"
+        }
+      ]
+    },
+    {
+      "@id": "fair2s:SoftwareAgentShape",
+      "@type": "sh:NodeShape",
+      "sh:targetClass": "prov:SoftwareAgent",
+      "sh:nodeKind": "sh:BlankNodeOrIRI",
+      "sh:property": [
+        {
+          "sh:path": "schema:name",
+          "sh:minCount": 1,
+          "sh:node": "fair2s:TextShape"
+        },
+        {
+          "sh:path": "schema:identifier",
+          "sh:node": "fair2s:IdentifierShape",
+          "sh:description": "Persistent identifier or homepage URL for the software."
+        },
+        {
+          "sh:path": "schema:softwareVersion",
+          "sh:node": "fair2s:TextShape"
+        },
+        {
+          "sh:path": "schema:programmingLanguage",
+          "sh:node": "fair2s:TextShape"
+        }
+      ]
+    }
+  ]
 }

--- a/shapes/turtle/access_rights.ttl
+++ b/shapes/turtle/access_rights.ttl
@@ -1,31 +1,31 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix schema: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 
 fair2s:AccessRightsShape
     a sh:NodeShape ;
     sh:targetClass schema:DefinedTerm ;
-    sh:nodeKind sh:IRI ; # Ensures the @id for the agreement level is present
+    sh:nodeKind sh:IRI ;
 
-    sh:property [ 
-        sh:path schema:name ; 
+    sh:property [
+        sh:path schema:name ;
         sh:node fair2s:TextShape ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    sh:property [ 
-        sh:path schema:definition ; 
+    sh:property [
+        sh:path skos:definition ;
         sh:node fair2s:TextShape ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    sh:property [ 
-        sh:path schema:note ; 
-        sh:node fair2s:TextShape 
+    sh:property [
+        sh:path skos:note ;
+        sh:node fair2s:TextShape
     ] ;
 
-    # Link to the official agreement specification
-    sh:property [ 
-        sh:path schema:url ; 
-        sh:nodeKind sh:IRI 
+    sh:property [
+        sh:path schema:url ;
+        sh:node fair2s:IdentifierShape
     ] .

--- a/shapes/turtle/certification.ttl
+++ b/shapes/turtle/certification.ttl
@@ -4,55 +4,39 @@
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# =============================================================================
-# DRAFT — pending governance decisions A, B, C
-# See docs/specification/certification.md#open-governance-decisions
-#
-# This shape is NOT yet wired into DatasetShape as a required property.
-# It is published to let producers experiment with the two-tier model;
-# semantics may change before it is finalised.
-# =============================================================================
-
 fair2s:CertificationShape
     a sh:NodeShape ;
     sh:targetClass fair2:Certification ;
 
-    # Who certified
     sh:property [
         sh:path fair2:certifiedBy ;
         sh:minCount 1 ;
         sh:node fair2s:OrganizationShape ;
     ] ;
 
-    # When
     sh:property [
         sh:path fair2:dateIssued ;
         sh:minCount 1 ;
         sh:datatype xsd:date ;
     ] ;
 
-    # Compliance-level label (FAIR2-Validated | FAIR2-Certified | …)
-    # Enumeration intentionally left open pending Decision A.
     sh:property [
         sh:path fair2:fair2ComplianceLevel ;
         sh:minCount 1 ;
         sh:node fair2s:IdentifierShape ;
     ] ;
 
-    # Pointer to full signed credential
     sh:property [
         sh:path fair2:certificationDocument ;
         sh:minCount 1 ;
         sh:node fair2s:IdentifierShape ;
     ] ;
 
-    # Human-facing verification endpoint
     sh:property [
         sh:path fair2:verificationEndpoint ;
         sh:nodeKind sh:IRI ;
     ] ;
 
-    # Declared scope of what was actually verified
     sh:property [
         sh:path fair2:certificationScope ;
         sh:minCount 1 ;

--- a/shapes/turtle/changelog.ttl
+++ b/shapes/turtle/changelog.ttl
@@ -1,5 +1,6 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix schema: <https://schema.org/> .
+@prefix fair2: <https://fair2.ai/ns/> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -7,36 +8,31 @@
 fair2s:UpdateActionShape
     a sh:NodeShape ;
     sh:targetClass schema:UpdateAction ;
-    
-    # Validation for the publication date of the update
-    sh:property [ 
-        sh:path schema:datePublished ; 
+
+    sh:property [
+        sh:path schema:datePublished ;
         sh:datatype xsd:date ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    # Custom nested description object for FAIR2 updates
     sh:property [
         sh:path schema:description ;
         sh:minCount 1 ;
         sh:node fair2s:UpdateDescriptionShape ;
     ] ;
 
-    # Linkage to the previous version
     sh:property [
         sh:path prov:wasRevisionOf ;
         sh:node fair2s:VersionReferenceShape ;
     ] .
 
-# Internal shape for the changelog description categories
 fair2s:UpdateDescriptionShape
     a sh:NodeShape ;
-    sh:property [ sh:path fair2s:newFeatures ; sh:node fair2s:TextShape ] ;
-    sh:property [ sh:path fair2s:improvements ; sh:node fair2s:TextShape ] ;
-    sh:property [ sh:path fair2s:bugFixes ; sh:node fair2s:TextShape ] ;
-    sh:property [ sh:path fair2s:otherInformation ; sh:node fair2s:TextShape ] .
+    sh:property [ sh:path fair2:newFeatures ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path fair2:improvements ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path fair2:bugFixes ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path fair2:otherInformation ; sh:node fair2s:TextShape ] .
 
-# Basic shape for the dataset version being revised
 fair2s:VersionReferenceShape
     a sh:NodeShape ;
     sh:property [ sh:path schema:identifier ; sh:node fair2s:IdentifierShape ] ;

--- a/shapes/turtle/common.ttl
+++ b/shapes/turtle/common.ttl
@@ -1,9 +1,9 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 
-# This is a reusable validator for the VALUE of a property
 fair2s:TextShape
     a sh:NodeShape ;
     sh:or (
@@ -12,7 +12,6 @@ fair2s:TextShape
     ) ;
     sh:message "Value must be a plain string (xsd:string) or a language-tagged string (rdf:langString)." .
 
-# Reusable shape for identifiers (DOIs, ORCIDs, RORs, URLs)
 fair2s:IdentifierShape
     a sh:NodeShape ;
     sh:or (
@@ -21,3 +20,21 @@ fair2s:IdentifierShape
         [ sh:datatype rdf:langString ]
     ) ;
     sh:message "Identifier must be a valid IRI (URL) or a text string." .
+
+fair2s:CreativeWorkShape
+    a sh:NodeShape ;
+    sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path schema:url ; sh:node fair2s:IdentifierShape ] .
+
+fair2s:GrantShape
+    a sh:NodeShape ;
+    sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path schema:funder ; sh:node fair2s:PersonOrOrganizationShape ] ;
+    sh:property [ sh:path schema:url ; sh:node fair2s:IdentifierShape ] ;
+    sh:property [ sh:path schema:identifier ; sh:node fair2s:IdentifierShape ] .
+
+fair2s:ContactShape
+    a sh:NodeShape ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path schema:identifier ; sh:node fair2s:IdentifierShape ] .

--- a/shapes/turtle/contributor.ttl
+++ b/shapes/turtle/contributor.ttl
@@ -1,11 +1,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix schema: <https://schema.org/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix fair2: <https://fair2.ai/ns/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# --- Shared Shape for Authors, Creators, and Affiliations ---
 fair2s:PersonOrOrganizationShape
     a sh:NodeShape ;
     sh:nodeKind sh:BlankNodeOrIRI ;
@@ -27,16 +27,13 @@ fair2s:OrganizationShape
         sh:node fair2s:TextShape ;
     ] .
 
-# --- CRediT / CRO contributor role ---
-# Accepts either:
-#   {"@id": "credit:Conceptualization", "label": "Conceptualization"}
-# or a PropertyValue-shaped node carrying propertyID "CRediT".
 fair2s:ContributorRoleShape
     a sh:NodeShape ;
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:or (
         [ sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ]
         [ sh:property [ sh:path schema:propertyID ; sh:minCount 1 ; sh:node fair2s:TextShape ] ]
+        [ sh:property [ sh:path rdfs:label ; sh:minCount 1 ; sh:node fair2s:TextShape ] ]
     ) .
 
 fair2s:ContributorShape

--- a/shapes/turtle/coverage.ttl
+++ b/shapes/turtle/coverage.ttl
@@ -1,17 +1,39 @@
-# Shape to validate the structured Place/Geo data
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix schema: <https://schema.org/> .
 @prefix fair2: <https://fair2.ai/ns/> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-schema:PlaceShape
+fair2s:SpatialCoverageShape
     a sh:NodeShape ;
+    sh:property [ sh:path schema:name ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path schema:description ; sh:node fair2s:TextShape ] ;
+    sh:property [ sh:path schema:identifier ; sh:node fair2s:IdentifierShape ] ;
     sh:property [
         sh:path schema:geo ;
-        sh:minCount 1 ;
-        sh:node schema:GeoCoordinatesShape ;
+        sh:or (
+            [ sh:node fair2s:GeoShapeShape ]
+            [ sh:node schema:GeoCoordinatesShape ]
+        ) ;
+    ] ;
+    sh:property [
+        sh:path schema:geoWithin ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ] ;
+    sh:property [
+        sh:path schema:containsPlace ;
+        sh:node fair2s:SpatialCoverageShape ;
     ] .
+
+fair2s:GeoShapeShape
+    a sh:NodeShape ;
+    sh:or (
+        [ sh:property [ sh:path schema:box ;     sh:minCount 1 ; sh:node fair2s:TextShape ] ]
+        [ sh:property [ sh:path schema:polygon ; sh:minCount 1 ; sh:node fair2s:TextShape ] ]
+        [ sh:property [ sh:path schema:line ;    sh:minCount 1 ; sh:node fair2s:TextShape ] ]
+        [ sh:property [ sh:path schema:circle ;  sh:minCount 1 ; sh:node fair2s:TextShape ] ]
+    ) ;
+    sh:message "A GeoShape must declare at least one geometry (box, polygon, line, or circle)." .
 
 schema:GeoCoordinatesShape
     a sh:NodeShape ;

--- a/shapes/turtle/data_archive.ttl
+++ b/shapes/turtle/data_archive.ttl
@@ -9,26 +9,20 @@ fair2s:DataArchiveShape
     sh:targetClass fair2:DataArchive ;
     sh:nodeKind sh:IRI ;
 
-    # --- Identity & Metadata ---
     sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:description ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:identifier ; sh:minCount 1 ; sh:node fair2s:IdentifierShape ] ;
     sh:property [ sh:path schema:keywords ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
 
-    # --- Archive Institution ---
     sh:property [ sh:path schema:holdingArchive ; sh:minCount 1 ; sh:node fair2s:IdentifierShape ] ;
 
-    # --- Authorship ---
     sh:property [ sh:path schema:author ; sh:minCount 1 ; sh:node fair2s:PersonOrOrganizationShape ] ;
 
-    # --- Versioning ---
     sh:property [ sh:path schema:version ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path fair2:changeLog ; sh:node fair2s:UpdateActionShape ] ;
 
-    # --- Life Cycle ---
     sh:property [ sh:path schema:dateCreated ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:datePublished ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:dateUpdated ; sh:datatype xsd:date ] ;
 
-    # --- Dataset Link ---
     sh:property [ sh:path fair2:dataset ; sh:node fair2s:IdentifierShape ] .

--- a/shapes/turtle/data_article.ttl
+++ b/shapes/turtle/data_article.ttl
@@ -8,18 +8,19 @@ fair2s:ArticleShape
     a sh:NodeShape ;
     sh:targetClass schema:ScholarlyArticle ;
     sh:nodeKind sh:IRI ;
-    
-    sh:property [ sh:path schema:headline ; sh:minCount 1 ] ;
+
+    sh:or (
+        [ sh:property [ sh:path schema:headline ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path schema:name ; sh:minCount 1 ] ]
+    ) ;
     sh:property [ sh:path schema:datePublished ; sh:minCount 1 ] ;
     sh:property [ sh:path schema:publisher ; sh:minCount 1 ] ;
-    
-    # Back-linkage validation
+
     sh:property [
         sh:path prov:wasDerivedFrom ;
         sh:minCount 1 ;
         sh:node fair2s:IdentifierShape
     ] ;
 
-    # Versioning
     sh:property [ sh:path schema:version ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path fair2:changeLog ; sh:node fair2s:UpdateActionShape ] .

--- a/shapes/turtle/data_portal.ttl
+++ b/shapes/turtle/data_portal.ttl
@@ -9,26 +9,20 @@ fair2s:DataPortalShape
     sh:targetClass fair2:DataPortal ;
     sh:nodeKind sh:IRI ;
 
-    # --- Identity & Metadata ---
     sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:description ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:identifier ; sh:minCount 1 ; sh:node fair2s:IdentifierShape ] ;
     sh:property [ sh:path schema:keywords ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
 
-    # --- Access ---
-    sh:property [ sh:path schema:url ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path schema:url ; sh:minCount 1 ; sh:node fair2s:IdentifierShape ] ;
 
-    # --- Authorship ---
     sh:property [ sh:path schema:author ; sh:minCount 1 ; sh:node fair2s:PersonOrOrganizationShape ] ;
 
-    # --- Versioning ---
     sh:property [ sh:path schema:version ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path fair2:changeLog ; sh:node fair2s:UpdateActionShape ] ;
 
-    # --- Life Cycle ---
     sh:property [ sh:path schema:dateCreated ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:datePublished ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:dateUpdated ; sh:datatype xsd:date ] ;
 
-    # --- Dataset Link ---
     sh:property [ sh:path fair2:dataset ; sh:node fair2s:IdentifierShape ] .

--- a/shapes/turtle/dataset.ttl
+++ b/shapes/turtle/dataset.ttl
@@ -13,11 +13,10 @@ fair2s:DatasetShape
     sh:targetClass schema:Dataset ;
     sh:nodeKind sh:IRI ;
 
-    # --- Standard Identity & Metadata ---
-    sh:property [ 
-        sh:path schema:name ; 
+    sh:property [
+        sh:path schema:name ;
         sh:node fair2s:TextShape ;
-        sh:minCount 1 ; 
+        sh:minCount 1 ;
         sh:message "Name must be a string or a language-tagged string."
     ] ;
     sh:property [ sh:path schema:description ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
@@ -27,48 +26,48 @@ fair2s:DatasetShape
     sh:property [ sh:path schema:url ; sh:minCount 1 ; sh:node fair2s:IdentifierShape ] ;
     sh:property [ sh:path schema:keywords ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
 
-    # --- Croissant (cr) Properties ---
     sh:property [ sh:path dct:conformsTo ; sh:minCount 1 ; sh:node fair2s:IdentifierShape] ;
     sh:property [ sh:path cr:citeAs ; sh:node fair2s:TextShape ] ;
 
-    # --- FAIR² & Methodological Properties ---
-    sh:property [ 
-        sh:path fair2:methodSection ; 
+    sh:property [
+        sh:path fair2:methodSection ;
         sh:node fair2s:MethodSectionShape
     ] ;
-    sh:property [ 
-        sh:path cr:recordSet ; 
+    sh:property [
+        sh:path cr:recordSet ;
         sh:node fair2s:RecordSetShape
     ] ;
 
-    # --- Roles & Participants ---
     sh:property [
         sh:path schema:creator ;
         sh:minCount 1 ;
         sh:node fair2s:PersonOrOrganizationShape
     ] ;
-    sh:property [ 
-        sh:path schema:contributor ; 
-        sh:node fair2s:ContributorShape 
+    sh:property [
+        sh:path schema:contributor ;
+        sh:node fair2s:ContributorShape
     ] ;
-    sh:property [ 
-        sh:path schema:funding ; 
-        sh:node fair2s:GrantShape 
-    ] ;
-
-    # --- Coverage & Distribution ---
-    sh:property [ sh:path schema:temporalCoverage ; sh:node fair2s:TextShape ] ;
-    sh:property [ 
-        sh:path schema:spatialCoverage ; 
-        sh:node fair2s:SpatialCoverageShape 
-    ] ;
-    sh:property [ 
-        sh:path schema:distribution ; 
-        sh:minCount 1 ; 
-        sh:node fair2s:DistributionShape 
+    sh:property [
+        sh:path schema:funding ;
+        sh:node fair2s:GrantShape
     ] ;
 
-    # --- Life Cycle & Context ---
+    sh:property [
+        sh:path schema:temporalCoverage ;
+        sh:node fair2s:TextShape ;
+        sh:pattern "^(\\d{4}(-\\d{2}(-\\d{2})?)?)(/(\\d{4}(-\\d{2}(-\\d{2})?)?|\\.\\.))?$" ;
+        sh:message "temporalCoverage must be an ISO 8601 date or interval (e.g. '1995-01-01/2023-12-31') for Google Dataset Search compliance."
+    ] ;
+    sh:property [
+        sh:path schema:spatialCoverage ;
+        sh:node fair2s:SpatialCoverageShape
+    ] ;
+    sh:property [
+        sh:path schema:distribution ;
+        sh:minCount 1 ;
+        sh:node fair2s:DistributionShape
+    ] ;
+
     sh:property [ sh:path schema:dateCreated ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:datePublished ; sh:datatype xsd:date ] ;
     sh:property [ sh:path schema:dateUpdated ; sh:datatype xsd:date ] ;
@@ -79,7 +78,6 @@ fair2s:DatasetShape
     sh:property [ sh:path fair2s:socialMedia ; sh:node fair2s:SocialMediaShape ] ;
     sh:property [ sh:path schema:accessRights ; sh:node fair2s:AccessRightsShape ] ;
 
-    # --- Links to Other Publication Products ---
     sh:property [
         sh:path fair2:dataArticle ;
         sh:minCount 1 ;

--- a/shapes/turtle/distribution.ttl
+++ b/shapes/turtle/distribution.ttl
@@ -4,12 +4,10 @@
 @prefix cr: <http://mlcommons.org/croissant/> .
 @prefix fair2s: <https://fair2.ai/shapes/> .
 
-
 schema:DistributionShape
     a sh:NodeShape ;
     sh:targetClass cr:FileObject ;
-    # Ensure this node has an @id (IRI) as per your error log focus node
-    sh:nodeKind sh:IRI ; 
+    sh:nodeKind sh:IRI ;
 
     sh:property [
         sh:path schema:name ;
@@ -32,7 +30,7 @@ schema:DistributionShape
         sh:minCount 1 ;
     ] ;
     sh:property [
-        sh:path cr:sha256 ;
+        sh:path schema:sha256 ;
         sh:node fair2s:TextShape ;
         sh:minCount 1 ;
     ] .

--- a/shapes/turtle/domain.ttl
+++ b/shapes/turtle/domain.ttl
@@ -6,7 +6,7 @@
 
 fair2s:DomainShape
     a sh:NodeShape ;
-    sh:nodeKind sh:IRI ; # Validates the Wikidata @id
+    sh:nodeKind sh:IRI ;
 
     sh:property [
         sh:targetClass schema:Thing ;
@@ -15,9 +15,8 @@ fair2s:DomainShape
         sh:node fair2s:TextShape ;
     ] ;
 
-    # Attribution to the person/expert
     sh:property [
         sh:path prov:wasAttributedTo ;
-        sh:node fair2s:ContactShape ; # Reuses your existing Person/Org shape
+        sh:node fair2s:ContactShape ;
         sh:description "The expert or authority who classified this dataset."
     ] .

--- a/shapes/turtle/method.ttl
+++ b/shapes/turtle/method.ttl
@@ -5,20 +5,19 @@
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# --- METHOD SECTION SHAPE ---
 fair2s:MethodSectionShape
     a sh:NodeShape ;
     sh:targetClass fair2:Section ;
     sh:nodeKind sh:IRI ;
     sh:description "Validates the high-level sections of the methodology (e.g., Research Design)." ;
 
-    sh:property [ 
-        sh:path schema:name ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path schema:name ;
+        sh:minCount 1 ;
         sh:node fair2s:TextShape
     ] ;
-    sh:property [ 
-        sh:path schema:description ; 
+    sh:property [
+        sh:path schema:description ;
         sh:node fair2s:TextShape
     ] ;
     sh:property [
@@ -34,7 +33,6 @@ fair2s:MethodSectionShape
     sh:property [
         sh:path fair2:step ;
         sh:minCount 0 ;
-        # Steps can be either a standard Step or a conditional StepCase
         sh:or (
             [ sh:node fair2s:MethodStepShape ]
             [ sh:node fair2s:StepCaseShape ]
@@ -42,7 +40,6 @@ fair2s:MethodSectionShape
         sh:description "The discrete operations within this section."
     ] .
 
-# --- METHOD STEP SHAPE ---
 fair2s:MethodStepShape
     a sh:NodeShape ;
     sh:targetClass fair2:Step ;
@@ -50,11 +47,10 @@ fair2s:MethodStepShape
 
     sh:property [ sh:path schema:name ; sh:minCount 1 ] ;
     sh:property [ sh:path schema:description ; sh:node fair2s:TextShape ] ;
-    
-    # Requirement: Step should always have a substep property
-    sh:property [ 
-        sh:path fair2:substep ; 
-        sh:minCount 0 ; 
+
+    sh:property [
+        sh:path fair2:substep ;
+        sh:minCount 0 ;
         sh:node fair2s:MethodSubstepShape ;
         sh:description "Standardized requirement for nested substeps."
     ] ;
@@ -71,37 +67,35 @@ fair2s:MethodStepShape
         sh:description "Lineage link to RecordSet fields."
     ] .
 
-# --- STEPCASE SHAPE (Conditional Logic) ---
 fair2s:StepCaseShape
     a sh:NodeShape ;
     sh:targetClass fair2:StepCase ;
     sh:nodeKind sh:IRI ;
     sh:description "Handles branching logic within the methodology." ;
     sh:property [ sh:path schema:name ; sh:minCount 1 ] ;
-    sh:property [ 
-        sh:path fair2:qualifiedUsage ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path fair2:qualifiedUsage ;
+        sh:minCount 1 ;
         sh:datatype xsd:string ;
         sh:description "The 'if' condition for this step."
     ] ;
-    sh:property [ 
-        sh:path fair2:nextTrue ; 
+    sh:property [
+        sh:path fair2:nextTrue ;
         sh:nodeKind sh:IRI ;
         sh:minCount 1 ;
         sh:description "The path taken if the condition is met."
     ] ;
-    sh:property [ 
-        sh:path fair2:next ; 
+    sh:property [
+        sh:path fair2:next ;
         sh:nodeKind sh:IRI ;
         sh:description "The default 'else' or 'next' path."
     ] .
 
-# --- METHOD SUBSTEP SHAPE ---
 fair2s:MethodSubstepShape
     a sh:NodeShape ;
     sh:targetClass fair2:Substep ;
     sh:nodeKind sh:IRI ;
-    
+
     sh:property [ sh:path schema:name ; sh:minCount 1 ] ;
     sh:property [ sh:path schema:description ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path fair2:next ; sh:nodeKind sh:IRI ] ;

--- a/shapes/turtle/provenance.ttl
+++ b/shapes/turtle/provenance.ttl
@@ -5,9 +5,6 @@
 @prefix fair2s: <https://fair2.ai/shapes/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# --- DIGITAL DOCUMENT SHAPE ---
-# Represents source documents (READMEs, data dictionaries, specifications)
-# referenced via prov:used in method sections and steps.
 fair2s:DigitalDocumentShape
     a sh:NodeShape ;
     sh:targetClass schema:DigitalDocument ;
@@ -17,11 +14,8 @@ fair2s:DigitalDocumentShape
     sh:property [ sh:path schema:pagination ; sh:node fair2s:TextShape ;
         sh:description "Relative file path to the document within the dataset package." ] ;
     sh:property [ sh:path schema:encodingFormat ; sh:node fair2s:TextShape ] ;
-    sh:property [ sh:path schema:url ; sh:nodeKind sh:IRI ] .
+    sh:property [ sh:path schema:url ; sh:node fair2s:IdentifierShape ] .
 
-
-# --- SOFTWARE SOURCE CODE SHAPE ---
-# Represents scripts and code files used or produced by method steps.
 fair2s:SoftwareSourceCodeShape
     a sh:NodeShape ;
     sh:targetClass schema:SoftwareSourceCode ;
@@ -32,34 +26,27 @@ fair2s:SoftwareSourceCodeShape
         sh:description "Relative path or persistent identifier for the script." ] ;
     sh:property [ sh:path schema:encodingFormat ; sh:node fair2s:TextShape ;
         sh:description "MIME type of the source file (e.g., text/x-python)." ] ;
-    sh:property [ sh:path schema:url ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path schema:url ; sh:node fair2s:IdentifierShape ] ;
     sh:property [ sh:path schema:programmingLanguage ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:runtimePlatform ; sh:node fair2s:TextShape ;
         sh:description "Runtime environment (e.g., Python 3.11, R 4.3)." ] .
 
-
-# --- ACTIVITY SHAPE ---
-# Represents a computational or manual activity in PROV-O.
-# Activities are associated with agents and generate or use entities.
 fair2s:ActivityShape
     a sh:NodeShape ;
     sh:targetClass prov:Activity ;
-    sh:nodeKind sh:IRI ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
 
     sh:property [ sh:path rdfs:label ; sh:minCount 1 ; sh:node fair2s:TextShape ;
         sh:description "Human-readable name for the activity." ] ;
-    sh:property [ sh:path prov:wasAssociatedWith ; sh:nodeKind sh:IRI ;
+    sh:property [ sh:path prov:wasAssociatedWith ; sh:nodeKind sh:BlankNodeOrIRI ;
         sh:description "The agent (SoftwareAgent, Person, Organization) responsible for this activity." ] ;
     sh:property [ sh:path schema:startTime ; sh:datatype xsd:dateTime ] ;
     sh:property [ sh:path schema:endTime ; sh:datatype xsd:dateTime ] .
 
-
-# --- SOFTWARE AGENT SHAPE ---
-# Represents a software tool or application that performed an activity.
 fair2s:SoftwareAgentShape
     a sh:NodeShape ;
     sh:targetClass prov:SoftwareAgent ;
-    sh:nodeKind sh:IRI ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
 
     sh:property [ sh:path schema:name ; sh:minCount 1 ; sh:node fair2s:TextShape ] ;
     sh:property [ sh:path schema:identifier ; sh:node fair2s:IdentifierShape ;

--- a/shapes/turtle/recordset.ttl
+++ b/shapes/turtle/recordset.ttl
@@ -5,83 +5,75 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-# --- RECORDSET SHAPE ---
 fair2s:RecordSetShape
     a sh:NodeShape ;
     sh:targetClass cr:RecordSet ;
     sh:nodeKind sh:IRI ;
 
-    sh:property [ 
-        sh:path schema:name ; 
-        sh:minCount 1 ; 
-        sh:node fair2s:TextShape ;
-        sh:message "Name must be a string or a language-tagged string."
-    ] ; 
-    sh:property [ 
-        sh:path schema:description ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path schema:name ;
+        sh:minCount 1 ;
         sh:node fair2s:TextShape ;
         sh:message "Name must be a string or a language-tagged string."
     ] ;
-    
-    # Croissant requirement: A RecordSet must have fields
-    sh:property [ 
-        sh:path cr:field ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path schema:description ;
+        sh:minCount 1 ;
+        sh:node fair2s:TextShape ;
+        sh:message "Name must be a string or a language-tagged string."
+    ] ;
+
+    sh:property [
+        sh:path cr:field ;
+        sh:minCount 1 ;
         sh:node fair2s:FieldShape ;
         sh:description "The columns/attributes defined within this record set."
     ] .
 
-# --- FIELD SHAPE ---
 fair2s:FieldShape
     a sh:NodeShape ;
     sh:targetClass cr:Field ;
     sh:nodeKind sh:IRI ;
 
-    sh:property [ 
-        sh:path schema:name ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path schema:name ;
+        sh:minCount 1 ;
         sh:node fair2s:TextShape ;
         sh:message "Name must be a string or a language-tagged string."
     ] ;
-    sh:property [ 
-        sh:path schema:description ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path schema:description ;
+        sh:minCount 1 ;
         sh:node fair2s:TextShape ;
         sh:message "Name must be a string or a language-tagged string."
     ] ;
-    # Croissant requirement: dataType (must be a URL like schema:Text or schema:Integer)
-    sh:property [ 
-        sh:path cr:dataType ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path cr:dataType ;
+        sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:description "The semantic type of the data (e.g., schema:Float)."
     ] ;
 
-    # Croissant requirement: source (tells the library how to extract the data)
-    sh:property [ 
-        sh:path cr:source ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path cr:source ;
+        sh:minCount 1 ;
         sh:node fair2s:SourceShape ;
         sh:description "The mapping to the physical file and column."
     ] .
 
-# --- SOURCE SHAPE ---
 fair2s:SourceShape
     a sh:NodeShape ;
     sh:nodeKind sh:BlankNodeOrIRI ;
 
-    # Pointing to the @id of the FileObject (DataDownload)
-    sh:property [ 
-        sh:path cr:fileObject ; 
-        sh:minCount 1 ; 
+    sh:property [
+        sh:path cr:fileObject ;
+        sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:description "The @id of the FileObject this field is extracted from."
     ] ;
 
-    # The specific column name or JSON path
-    sh:property [ 
-        sh:path cr:extract ; 
+    sh:property [
+        sh:path cr:extract ;
         sh:node [
             sh:property [ sh:path cr:column ; sh:minCount 1 ; sh:node fair2s:TextShape ]
         ] ;

--- a/shapes/turtle/social_media.ttl
+++ b/shapes/turtle/social_media.ttl
@@ -5,30 +5,26 @@
 
 fair2s:SocialMediaShape
     a sh:NodeShape ;
-    
-    # Technical platform identifier (e.g., "linkedin")
-    sh:property [ 
-        sh:path schema:identifier ; 
+
+    sh:property [
+        sh:path schema:identifier ;
         sh:node fair2s:IdentifierShape ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    # Link to the social platform
-    sh:property [ 
-        sh:path fair2s:accountServiceHomePage ; 
+    sh:property [
+        sh:path fair2s:accountServiceHomePage ;
         sh:nodeKind sh:IRI ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    # The content of the social media post
-    sh:property [ 
-        sh:path schema:articleBody ; 
+    sh:property [
+        sh:path schema:articleBody ;
         sh:node fair2s:TextShape ;
-        sh:minCount 1 
+        sh:minCount 1
     ] ;
 
-    # Array of strings for tags/keywords
-    sh:property [ 
-        sh:path schema:keywords ; 
-        sh:node fair2s:TextShape 
+    sh:property [
+        sh:path schema:keywords ;
+        sh:node fair2s:TextShape
     ] .


### PR DESCRIPTION
Reconcile examples/example-1/borja2025.json so it validates with SHACL (Conforms: True) and loads with mlcroissant, and bring the reference context, SHACL shapes, and docs into alignment.

Example (borja2025.json):
- Add url, restore human-readable name, port full spatialCoverage (bbox + convex hull + 714 sampling sites), rename method -> methodSection
- Identity: Dataset @id = DOI, url = sen.science landing page, identifier = DOI; DataArchive @id/url = Zenodo DOI; references updated
- temporalCoverage as ISO-8601 interval (Google Dataset Search compliant)
- Fill RecordSet names and missing field descriptions
- De-normalize for mlcroissant: remove reference cycles (self-referential url, bbox/hull geoWithin, dataset back-links), use schema:sha256
- Remove DataPortal node/link from the package metadata (shape & docs kept)
- Align @context with the standardized reference context

Reference context (fair2_context.json):
- Full superset of example terms, alphabetized (prefixes, classes, properties); add skos/schema/sh/xsd prefixes, date typing, and missing fair2/prov/skos terms

Shapes (shapes/turtle + shapes/json-ld):
- Add SpatialCoverageShape, GeoShapeShape, CreativeWorkShape, GrantShape, ContactShape
- Fix paths: changelog fair2s->fair2, access_rights schema->skos, distribution cr:sha256->schema:sha256
- Relax url/agent nodeKind, accept name-or-headline for articles, role rdfs:label; enforce ISO-8601 temporalCoverage via sh:pattern
- Strip all comments from shape files

Docs:
- schema.md and fair2-ontology.md updated for new shapes/classes/properties
- Add .github issue template for Croissant/mlcroissant compatibility